### PR TITLE
fix: clear verbosity on response and lower jwt duration

### DIFF
--- a/src/api/auth/auth_service.ts
+++ b/src/api/auth/auth_service.ts
@@ -50,7 +50,7 @@ export async function handleLogin(id: string, pass: string, is_admin?: boolean) 
         if (!student) {
             return {
                 success: false,
-                reason: "Incorrect ID or Password"
+                reason: "Invalid credentials!"
             };
         }
         
@@ -60,7 +60,8 @@ export async function handleLogin(id: string, pass: string, is_admin?: boolean) 
         if (!hash) {
             return {
                 success: false,
-                reason: "You're not verified yet, please wait for confirmation!"
+                reason: "Invalid credentials!"
+                //reason: "You're not verified yet, please wait for confirmation!"
             }
         }
 
@@ -82,13 +83,13 @@ export async function handleLogin(id: string, pass: string, is_admin?: boolean) 
 
         return {
             success: false,
-            reason: "Incorrect ID or Password"
+            reason: "Invalid credentials!"
         }
     }
 }
 
 export async function jwtGen(user: object) {
-    const token = jwt.sign(user, jwt_sauce as string, { expiresIn: '3h'});
+    const token = jwt.sign(user, jwt_sauce as string, { expiresIn: '1h' });
     return token;
 }
 


### PR DESCRIPTION
This pull request standardizes the error messages returned by the `handleLogin` function in `auth_service.ts` and reduces the JWT token expiration time. The changes improve security by making authentication error responses less specific and tightening token validity.

**Authentication error handling:**

* Standardized all authentication failure messages in `handleLogin` to return "Invalid credentials!" instead of more specific reasons, preventing information disclosure about account status.
* Reduced the JWT token expiration time from 3 hours to 1 hour in the `jwtGen` function for enhanced security.