### PR TITLE
fix: use strict sameSite, some npm audit fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,9 +1072,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/config": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.6.0.tgz",
-      "integrity": "sha512-MuAz1MK4PeG5/03YzfzX3CnFVHQ6qePGwUpQRzPzX5tT0ffJ3Tzi9zJZbBc+VzEGFCM8ghW/gTVDR85Syjt+Yw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.7.0.tgz",
+      "integrity": "sha512-hmPI3tKLO2aP0Y5vugbjcnA9qqlfJndiT6ds4tw28U5hNHLWg+mHJEWAhjsSPgxjtmxhJ/EDIeIlyh+3Us0OPg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1126,17 +1126,17 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.6.0.tgz",
-      "integrity": "sha512-Sn5edRzhHqgRV2M+A0eIbY442B4mReWWf3pKs/LKreYgW7oa/up8JtK/s4iv/EQA097cyboZ08mmkpbLp+tZ3w==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.7.0.tgz",
+      "integrity": "sha512-7fmcbT7HHXBq/b+3h/dO1JI3fd8l8q7erf7xP7pRprh58hmSSnG8mg9K3yjW3h9WaHWUwngVFpSxxxivaitQ2w==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.6.0",
+        "@prisma/debug": "7.7.0",
         "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
-        "@prisma/fetch-engine": "7.6.0",
-        "@prisma/get-platform": "7.6.0"
+        "@prisma/fetch-engine": "7.7.0",
+        "@prisma/get-platform": "7.7.0"
       }
     },
     "node_modules/@prisma/engines-version": {
@@ -1147,49 +1147,49 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/debug": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.6.0.tgz",
-      "integrity": "sha512-LpHr3qos4lQZ6sxwjStf59YBht7m9/QF7NSQsMH6qGENWZu2w3UkQUGn1h5iRkDjnWRj3VHykOu9qFhps4ADvA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.7.0.tgz",
+      "integrity": "sha512-12J62XdqCmpiwJHhHdQxZeY3ckVCWIFmcJP8hg5dPTceeiQ0wiojXGFYTluKqFQfu46fRLgb/rLALZMAx3+dTA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.6.0.tgz",
-      "integrity": "sha512-ohZDwXvtmnbzOcutR2D13lDWpZP1wQjmPyztmt0AwXLzQI7q95EE7NYCvS+M6N6SivT+BM0NOqLmTH3wms4L3A==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.7.0.tgz",
+      "integrity": "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.6.0"
+        "@prisma/debug": "7.7.0"
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.6.0.tgz",
-      "integrity": "sha512-N575Ni95c3FkduWY/eKTHqNYgNbceZ1tQaSknVtJjpKmiiBXmniESn/GTxsDvICC4ZeiNrXxioGInzQrCdx16w==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.7.0.tgz",
+      "integrity": "sha512-TfyzveBQoK4xALzsTpVhB/0KG1N8zOK0ap+RnBMkzGUu3f98fnQ4QtXa2wlKPhsO2X8a3N5ugFQgcKNoHGmDfw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.6.0",
+        "@prisma/debug": "7.7.0",
         "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
-        "@prisma/get-platform": "7.6.0"
+        "@prisma/get-platform": "7.7.0"
       }
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.6.0.tgz",
-      "integrity": "sha512-LpHr3qos4lQZ6sxwjStf59YBht7m9/QF7NSQsMH6qGENWZu2w3UkQUGn1h5iRkDjnWRj3VHykOu9qFhps4ADvA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.7.0.tgz",
+      "integrity": "sha512-12J62XdqCmpiwJHhHdQxZeY3ckVCWIFmcJP8hg5dPTceeiQ0wiojXGFYTluKqFQfu46fRLgb/rLALZMAx3+dTA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.6.0.tgz",
-      "integrity": "sha512-ohZDwXvtmnbzOcutR2D13lDWpZP1wQjmPyztmt0AwXLzQI7q95EE7NYCvS+M6N6SivT+BM0NOqLmTH3wms4L3A==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.7.0.tgz",
+      "integrity": "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.6.0"
+        "@prisma/debug": "7.7.0"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -2816,9 +2816,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
-      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -3399,9 +3399,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -3885,9 +3885,9 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -4188,16 +4188,16 @@
       }
     },
     "node_modules/prisma": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.6.0.tgz",
-      "integrity": "sha512-OKJIPT81K3+F+AayIkY/Y3mkF2NWoFh7lZApaaqPYy7EHILKdO0VsmGkP+hDKYTySHsFSyLWXm/JgcR1B8fY1Q==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.7.0.tgz",
+      "integrity": "sha512-HlgwRBt1uEFB9LStHL4HLYDvoi4BNu1rYA0hPG0zCAEyK9SaZBqp7E5Rjpc3Qh8Lex/ye/svoHZ0OWoFNhWxuQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "7.6.0",
+        "@prisma/config": "7.7.0",
         "@prisma/dev": "0.24.3",
-        "@prisma/engines": "7.6.0",
+        "@prisma/engines": "7.7.0",
         "@prisma/studio-core": "0.27.3",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
@@ -4744,9 +4744,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/src/api/auth/auth_controller.ts
+++ b/src/api/auth/auth_controller.ts
@@ -38,7 +38,7 @@ export async function handleLogin(req: Request, res: Response) {
         res.cookie("token", token, {
             httpOnly: true,
             secure: is_secure,
-            sameSite: 'lax',
+            sameSite: 'strict',
             maxAge: 1000 * 60 * 60,
             path: '/'
         });
@@ -78,7 +78,7 @@ export async function handleLogout(req: Request, res: Response) {
     res.clearCookie("token", {
         httpOnly: true,
         secure: is_secure,
-        sameSite: 'lax',
+        sameSite: 'strict',
         path: '/'
     });
 


### PR DESCRIPTION
This pull request makes a small but important security improvement to the authentication system by updating the cookie settings for login and logout actions. The `sameSite` attribute for the authentication token cookie is changed from `'lax'` to `'strict'`, which strengthens CSRF (Cross-Site Request Forgery) protection.

Security improvements to cookie handling:

* Changed the `sameSite` attribute from `'lax'` to `'strict'` when setting the authentication token cookie in `handleLogin`, ensuring cookies are only sent for same-site requests.
* Updated the `sameSite` attribute from `'lax'` to `'strict'` when clearing the authentication token cookie in `handleLogout`, maintaining consistent and stricter CSRF protection.