### PR TITLE
feat: secure data export endpoint with reauthentication

### DIFF
--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -256,6 +256,45 @@ export async function fetchMasterlist(req: Request, res: Response) {
   }
 }
 
+const ALLOWED_STUDENT_COLS = new Set([
+  "student_number", "first_name", "last_name", "mid_name", "nickname", "suffix",
+  "department", "course", "major", "thesis_title", "school_email", "personal_email", "created_at",
+]);
+const ALLOWED_DETAIL_COLS = new Set([
+  "birth_date", "province", "city", "barangay",
+  "mothers_name", "mothers_title", "fathers_name", "fathers_title",
+  "guardians_name", "guardians_title", "contact_num",
+]);
+
+export async function exportMasterlist(req: Request, res: Response) {
+  try {
+    const dept = String(req.query.dept ?? "ALL");
+    const course = String(req.query.course ?? "ALL");
+    const major = String(req.query.major ?? "ALL");
+    const status = String(req.query.status ?? "ALL");
+
+    const rawCols = String(req.query.columns ?? "");
+    const cols = rawCols.split(",").map(c => c.trim()).filter(Boolean);
+
+    const students = await adminService.m_exportAll(dept, course, major, status);
+
+    const rows = students.map(s => {
+      const row: Record<string, any> = {};
+      for (const col of cols) {
+        if (ALLOWED_STUDENT_COLS.has(col)) row[col] = (s as any)[col] ?? null;
+        else if (ALLOWED_DETAIL_COLS.has(col)) row[col] = (s.studentDetail as any)?.[col] ?? null;
+        else if (col === "status") row[col] = s.studentAuth?.status ?? null;
+      }
+      return row;
+    });
+
+    return res.json({ success: true, data: rows, total: rows.length });
+  } catch (err) {
+    console.error("Export error:", err);
+    return res.status(500).json({ status: "Internal Server Error" });
+  }
+}
+
 export async function fetchAttendedStudents(req: Request, res: Response) {
   const page = Number(req.query.page ?? 1);
   

--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -8,6 +8,25 @@ interface AdminRequest extends Request {
   }
 }
 
+export async function verifyPassword(req: AdminRequest, res: Response) {
+  const admin_id = req.user?.admin_id;
+  if (!admin_id) return res.status(401).json({ reason: "Unauthorized" });
+
+  const { password } = req.body;
+  if (typeof password !== "string" || !password) {
+    return res.status(400).json({ reason: "Password is required." });
+  }
+
+  try {
+    const valid = await adminService.verifyAdminPassword(admin_id, password);
+    if (!valid) return res.status(401).json({ reason: "Incorrect password." });
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("Password verify error:", err);
+    return res.status(500).json({ reason: "Internal Server Error" });
+  }
+}
+
 export async function getStaffDetails(req: AdminRequest, res: Response) {
   try {
     const id = req.user?.admin_id;

--- a/src/api/admin/admin_route.ts
+++ b/src/api/admin/admin_route.ts
@@ -19,6 +19,7 @@ router.patch("/student/:id", adminController.handleVerify);
 router.delete("/student/:id", adminController.handleCancel);
 
 //masterlist
+router.get("/masterlist/export", adminController.exportMasterlist);
 router.get("/masterlist", adminController.fetchMasterlist);
 router.post("/masterlist/reset/:id", adminController.handleStudentPasswordReset);
 

--- a/src/api/admin/admin_route.ts
+++ b/src/api/admin/admin_route.ts
@@ -6,6 +6,9 @@ const router = Router();
 //get admin's profile
 router.get("/profile", adminController.getStaffDetails);
 
+//verify admin password (used before sensitive actions)
+router.post("/verify-password", adminController.verifyPassword);
+
 //get all unverified students
 router.get("/student", adminController.fetchUnverifiedStudents);
 

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -59,6 +59,15 @@ const STUDENT_DETAIL_FAMILY_FIELDS = new Set([
   "guardians_name"
 ]);
 
+export async function verifyAdminPassword(admin_id: string, password: string) {
+  const admin = await prisma.admin.findUnique({
+    where: { id: parseInt(admin_id) },
+    select: { hashed_password: true },
+  });
+  if (!admin) return false;
+  return bcrypt.compare(password, admin.hashed_password);
+}
+
 export async function getStaffProfile(id: string) {
   try {
     const staff = await prisma.admin.findUnique({

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -485,6 +485,27 @@ export async function m_queryById(student_id: number) {
   return { success: true, student };
 }
 
+export async function m_exportAll(dept: string, course: string, major: string, status: string) {
+  const where: any = {};
+  if (dept !== "ALL") where.department = dept;
+  if (course !== "ALL") where.course = course;
+  if (major !== "ALL") where.major = major;
+
+  if (status !== "ALL") {
+    const status_map = STATUS_MAP[Number(status)];
+    if (status_map) where.studentAuth = { status: status_map };
+  }
+
+  return prisma.student.findMany({
+    orderBy: { student_number: "asc" },
+    where,
+    include: {
+      studentDetail: true,
+      studentAuth: { select: { status: true } },
+    },
+  });
+}
+
 //get paginated students where status is 'ATTENDED'
 export async function fv_queryStudents(page: number) {
   const skip = (page - 1) * F_STUDENTS_PER_PAGE;


### PR DESCRIPTION
## Summary

- Add `GET /api/admin/masterlist/export` — queries all matching students (no
  pagination) with dept/course/major/status filters and returns only the
  explicitly requested columns as JSON. An allowlist (`ALLOWED_STUDENT_COLS`,
  `ALLOWED_DETAIL_COLS`) enforces that `StudentAuth` credential fields can
  never be included in a response.
- Add `POST /api/admin/verify-password` — re-authenticates the current admin
  session by bcrypt-comparing the supplied password against `hashed_password`.
  Used to gate sensitive one-off actions without requiring a full re-login.
- Add `m_exportAll()` service function and `verifyAdminPassword()` service
  function backing the two endpoints above.