### PR TITLE
feat: role-based management requests

### DIFF
--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -456,7 +456,7 @@ export async function handleStudentPasswordReset(req: AdminRequest, res: Respons
     return res.status(401).json({
       error: "No target email provided!"
     });
-  } 
+  }
 
   const result = await adminService.resetStudentPass(id, target);
   if (!result.success) {
@@ -466,4 +466,46 @@ export async function handleStudentPasswordReset(req: AdminRequest, res: Respons
   }
 
   res.json({ status: 'success' });
+}
+
+export async function fetchStaffList(req: AdminRequest, res: Response) {
+  try {
+    const result = await adminService.getAdminList();
+    if (!result.success) {
+      return res.status(400).json({ reason: result.reason });
+    }
+    return res.json(result.admins);
+  } catch (err) {
+    console.error("Error:", err);
+    return res.status(500).json({ status: 'Internal Server Error' });
+  }
+}
+
+export async function handleUpdateAdminRole(req: AdminRequest, res: Response) {
+  const { id } = req.params;
+  const { role } = req.body;
+  const requesterId = req.user?.admin_id;
+
+  if (typeof id !== 'string' || Number.isNaN(Number(id))) {
+    return res.status(400).json({ reason: "Invalid admin ID." });
+  }
+
+  if (typeof role !== 'string' || !role) {
+    return res.status(400).json({ reason: "Role is required." });
+  }
+
+  if (String(requesterId) === id) {
+    return res.status(400).json({ reason: "You cannot change your own role." });
+  }
+
+  try {
+    const result = await adminService.updateAdminRole(Number(id), role);
+    if (!result.success) {
+      return res.status(400).json({ reason: result.reason });
+    }
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("Error:", err);
+    return res.status(500).json({ status: 'Internal Server Error' });
+  }
 }

--- a/src/api/admin/admin_route.ts
+++ b/src/api/admin/admin_route.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import * as adminController from "./admin_controller";
+import { isAdministrator } from "../auth/auth_middleware";
 
 const router = Router();
 
@@ -42,5 +43,9 @@ router.post("/book/add", adminController.addSchedule);
 router.get("/book/fetch", adminController.fetchSchedule);
 router.patch("/book/toggle", adminController.handleToggleScheduleState);
 router.patch("/book/update", adminController.handleUpdateScheduleCapacity);
+
+// staff role management (Administrator only)
+router.get("/staff/list", isAdministrator, adminController.fetchStaffList);
+router.patch("/staff/:id/role", isAdministrator, adminController.handleUpdateAdminRole);
 
 export default router;

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -689,6 +689,47 @@ export async function fv_markFullyVerified(studentId: number, adminId: number) {
   }
 }
 
+export async function getAdminList() {
+  try {
+    const admins = await prisma.admin.findMany({
+      where: {
+        NOT: { role: 'ADMINISTRATOR' }
+      },
+      select: {
+        id: true,
+        first_name: true,
+        last_name: true,
+        email: true,
+        role: true,
+        last_login: true
+      },
+      orderBy: { last_name: 'asc' }
+    });
+    return { success: true, admins };
+  } catch (err) {
+    console.error("getAdminList error:", err);
+    return { success: false, reason: "Something went wrong!" };
+  }
+}
+
+export async function updateAdminRole(targetId: number, newRole: string) {
+  const validRoles = ['MODERATOR', 'MEMBER'];
+  if (!validRoles.includes(newRole)) {
+    return { success: false, reason: "Invalid role. Only MODERATOR or MEMBER are allowed." };
+  }
+
+  try {
+    await prisma.admin.update({
+      where: { id: targetId },
+      data: { role: newRole as any }
+    });
+    return { success: true };
+  } catch (err) {
+    console.error("updateAdminRole error:", err);
+    return { success: false, reason: "Admin not found or update failed." };
+  }
+}
+
 export async function fv_updateStudent(studentId: number, type: string, data: any) {
   try {
     const normalizedType = String(type).toLowerCase() as FinalizeUpdateType;

--- a/src/api/auth/auth_middleware.ts
+++ b/src/api/auth/auth_middleware.ts
@@ -34,3 +34,14 @@ export function isAdmin(req: AuthRequest, res: Response, next: NextFunction) {
         });
     }
 }
+
+// ADMINISTRATOR-only guard (role is embedded in JWT at login time)
+export function isAdministrator(req: AuthRequest, res: Response, next: NextFunction) {
+    if (req.user && req.user.role === 'ADMINISTRATOR') {
+        next();
+    } else {
+        return res.status(403).json({
+            error: "Forbidden! This action requires Administrator access."
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- Added isAdministrator middleware to auth_middleware.ts that checks req.user.role === 'ADMINISTRATOR' from the JWT (no extra DB lookup needed — role is already embedded at login)
- Added getAdminList() and updateAdminRole() to admin_service.ts — fetches all non-ADMINISTRATOR admins and validates/applies MODERATOR or MEMBER role changes
- Added fetchStaffList and handleUpdateAdminRole controller handlers to admin_controller.ts — includes a self-role-change guard
- Added two new routes to admin_route.ts behind the isAdministrator middleware: GET /api/admin/staff/list and PATCH /api/admin/staff/:id/role