### PR TITLE
feat: validate scheduler requests

### DIFF
--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -206,6 +206,13 @@ export async function addSchedule(req: Request, res: Response) {
     });
 
   } catch(err) {
+    if (err instanceof Error && err.message === 'PAST_SCHEDULE_DATE') {
+      return res.status(400).json({
+        status: 'failed',
+        reason: 'Cannot create a schedule for a date that has already passed.'
+      });
+    }
+
     if ( err instanceof Prisma.PrismaClientKnownRequestError) {
       if (err.code === 'P2002') {
         return res.status(409).json({

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -346,10 +346,26 @@ export async function getUnverifiedStudentById(student_id: number) {
 } 
 
 //add schedule per day
+function isPastUtcDate(date: Date) {
+  const compareDate = new Date(date);
+  compareDate.setUTCHours(0, 0, 0, 0);
+
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  return compareDate < today;
+}
+
 export async function addSchedule(date: string, am_cap: number, pm_cap: number) {
+  const scheduleDate = new Date(`${date}T00:00:00.000Z`);
+
+  if (isPastUtcDate(scheduleDate)) {
+    throw new Error("PAST_SCHEDULE_DATE");
+  }
+
   return prisma.bookingDay.create({
     data: {
-      date: new Date(`${date}T00:00:00.000Z`),
+      date: scheduleDate,
       max_morning_cap: am_cap,
       max_afternoon_cap: pm_cap
     }
@@ -390,6 +406,7 @@ export async function toggleScheduleState(id: number) {
       select: {
         id: true,
         is_open: true,
+        date: true,
       }
     });
 
@@ -397,6 +414,14 @@ export async function toggleScheduleState(id: number) {
       return {
         success: false,
         reason: `Booking with ID ${id} is not found`
+      };
+    }
+
+    //block invalid date inputs
+    if (!booking_day.is_open && isPastUtcDate(booking_day.date)) {
+      return {
+        success: false,
+        reason: "Cannot re-open a schedule date that has already passed."
       };
     }
 


### PR DESCRIPTION
This pull request adds important validation to prevent creating or re-opening schedules for dates that have already passed, improving data integrity in the scheduling system. The main changes include new date validation logic, error handling, and updates to the schedule toggling process.

**Schedule Date Validation and Error Handling**
- Added a helper function `isPastUtcDate` to check if a given date is in the past (UTC), and integrated this check into the `addSchedule` service to block creation of schedules for past dates. If a past date is detected, an error with the message `PAST_SCHEDULE_DATE` is thrown. (`src/api/admin/admin_service.ts`)
- Updated the `addSchedule` controller to catch the `PAST_SCHEDULE_DATE` error and return a 400 response with a clear error message to the client. (`src/api/admin/admin_controller.ts`)

**Schedule State Toggling Improvements**
- Modified the `toggleScheduleState` service to include the schedule `date` in its selection, enabling date-based validation. (`src/api/admin/admin_service.ts`)
- Added logic to prevent re-opening a schedule if its date has already passed, returning a failure response with an appropriate reason. (`src/api/admin/admin_service.ts`)