### PR TITLE
Standardize thesis titles using APA title case

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "nodemon",
     "build": "tsc",
+    "test:title-case": "npm run build && node --test tests/thesis_title.test.cjs",
+    "thesis-title:backfill": "npm run build && node dist/scripts/standardize_thesis_titles.js",
     "start": "node dist/index.js"
   },
   "keywords": [],

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -4,6 +4,7 @@ import bcrypt from "bcrypt";
 import { Resend } from 'resend';
 import { AdminActions, StudentStatus } from "@prisma/client";
 import { generateReadUrl } from "../student/r2_service";
+import { formatApaThesisTitle } from "../../utils/thesis_title";
 
 const resend = new Resend(process.env.RESEND_API);
 const DOMAIN = "auriumi.cloud";
@@ -814,7 +815,10 @@ export async function fv_updateStudent(studentId: number, type: string, data: an
       const studentData: Record<string, any> = {};
       for (const [key, value] of payloadEntries) {
         const fieldKey = key === "thesis" ? "thesis_title" : key;
-        studentData[fieldKey] = value;
+        studentData[fieldKey] =
+          key === "thesis" && typeof value === "string"
+            ? formatApaThesisTitle(value)
+            : value;
       }
 
       await prisma.student.update({

--- a/src/api/student/student_controller.ts
+++ b/src/api/student/student_controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { generatePresignedUrl } from "./r2_service";
 import * as studentService from "./student_service";
 import * as r2Service from "./r2_service";
+import { formatApaThesisTitle } from "../../utils/thesis_title";
 
 interface StudentRequest extends Request {
     user?: {
@@ -234,4 +235,21 @@ export async function saveSolicitations(req: StudentRequest, res: Response) {
             message: "Server error nyae",
         });
     }
+}
+
+export function previewThesisTitle(req: Request, res: Response) {
+    const { title } = req.body;
+
+    if (typeof title !== "string") {
+        return res.status(400).json({
+            error: "Thesis title must be a string.",
+        });
+    }
+
+    const standardized = formatApaThesisTitle(title);
+    return res.json({
+        original: title,
+        standardized,
+        changed: standardized !== title,
+    });
 }

--- a/src/api/student/student_route.ts
+++ b/src/api/student/student_route.ts
@@ -5,6 +5,7 @@ const router = Router();
 
 //handle registration
 router.post("/submit", studentController.studentRegistration);
+router.post("/thesis-title/preview", studentController.previewThesisTitle);
 
 //fetch student profile respective to the id number
 router.get("/profile/fetch", studentController.getStudentById);

--- a/src/api/student/student_service.ts
+++ b/src/api/student/student_service.ts
@@ -1,6 +1,7 @@
 import { SolicitationType, StudentStatus } from "@prisma/client";
 import prisma from "../../config/prisma";
 import { generateReadUrl } from "./r2_service";
+import { formatApaThesisTitle } from "../../utils/thesis_title";
 
 type SolicitationPayload = {
   type: SolicitationType;
@@ -22,7 +23,7 @@ export async function createStudent(body: any) {
       major: body.academics.major,
       nickname: body.nickname,
       suffix: body.suffix,
-      thesis_title: body.academics.thesis,      
+      thesis_title: formatApaThesisTitle(body.academics.thesis),
 
       studentDetail: {
         create: {

--- a/src/scripts/standardize_thesis_titles.ts
+++ b/src/scripts/standardize_thesis_titles.ts
@@ -1,0 +1,54 @@
+import prisma from "../config/prisma";
+import { formatApaThesisTitle } from "../utils/thesis_title";
+
+async function main() {
+  const shouldApply = process.argv.includes("--apply");
+  const students = await prisma.student.findMany({
+    where: {
+      thesis_title: {
+        not: null,
+      },
+    },
+    select: {
+      student_number: true,
+      thesis_title: true,
+    },
+  });
+
+  const changes = students.flatMap((student) => {
+    const original = student.thesis_title ?? "";
+    const standardized = formatApaThesisTitle(original);
+
+    return original !== standardized
+      ? [{ studentNumber: student.student_number, original, standardized }]
+      : [];
+  });
+
+  console.table(changes);
+  console.log(
+    `${changes.length} thesis title(s) would be standardized. ` +
+      (shouldApply ? "Applying changes." : "Dry run only; pass --apply to update records."),
+  );
+
+  if (!shouldApply || changes.length === 0) {
+    return;
+  }
+
+  await prisma.$transaction(
+    changes.map((change) =>
+      prisma.student.update({
+        where: { student_number: change.studentNumber },
+        data: { thesis_title: change.standardized },
+      }),
+    ),
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/utils/thesis_title.ts
+++ b/src/utils/thesis_title.ts
@@ -1,0 +1,146 @@
+const MINOR_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "as",
+  "at",
+  "but",
+  "by",
+  "for",
+  "if",
+  "in",
+  "nor",
+  "of",
+  "on",
+  "or",
+  "per",
+  "so",
+  "the",
+  "to",
+  "up",
+  "via",
+  "yet",
+]);
+
+const INTENTIONAL_CASE = new Map([
+  ["ai", "AI"],
+  ["api", "API"],
+  ["covid-19", "COVID-19"],
+  ["css", "CSS"],
+  ["ehealth", "eHealth"],
+  ["elearning", "eLearning"],
+  ["html", "HTML"],
+  ["ict", "ICT"],
+  ["iot", "IoT"],
+  ["it", "IT"],
+  ["lgbtq+", "LGBTQ+"],
+  ["stem", "STEM"],
+  ["tvl", "TVL"],
+  ["ui", "UI"],
+  ["um", "UM"],
+]);
+
+// Add organization-specific proper names here when their official casing
+// cannot be derived from ordinary APA title-case rules.
+const PROTECTED_PHRASES = [
+  "City of Davao",
+  "Davao de Oro",
+  "Davao del Norte",
+  "Davao del Sur",
+  "Davao Occidental",
+  "Davao Oriental",
+  "Island Garden City of Samal",
+  "Santo Tomas",
+  "University of Mindanao",
+];
+
+const WORD_PART_PATTERN = /^([^A-Za-z0-9]*)(.*?)([^A-Za-z0-9+]*?)$/;
+const SUBTITLE_SEPARATOR_PATTERN = /[:?!\u2013\u2014]$/;
+
+function capitalizeWord(word: string) {
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+}
+
+function hasIntentionalMixedCase(word: string) {
+  return (
+    /[a-z]/.test(word) &&
+    /[A-Z]/.test(word) &&
+    !/^[A-Z][a-z]+(?:'[a-z]+)?$/.test(word)
+  );
+}
+
+function formatWordCore(core: string, forceCapitalize: boolean, isLastWord: boolean) {
+  const configuredCase = INTENTIONAL_CASE.get(core.toLowerCase());
+  if (configuredCase) {
+    return configuredCase;
+  }
+
+  if (hasIntentionalMixedCase(core)) {
+    return core;
+  }
+
+  const parts = core.split("-");
+  return parts
+    .map((part, index) => {
+      if (!part) {
+        return part;
+      }
+
+      const partConfiguredCase = INTENTIONAL_CASE.get(part.toLowerCase());
+      if (partConfiguredCase) {
+        return partConfiguredCase;
+      }
+
+      if (hasIntentionalMixedCase(part)) {
+        return part;
+      }
+
+      const shouldCapitalize =
+        forceCapitalize ||
+        isLastWord ||
+        !MINOR_WORDS.has(part.toLowerCase()) ||
+        index > 0;
+
+      return shouldCapitalize ? capitalizeWord(part) : part.toLowerCase();
+    })
+    .join("-");
+}
+
+function restoreProtectedPhrases(title: string) {
+  return PROTECTED_PHRASES.reduce((result, phrase) => {
+    const escapedPhrase = phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return result.replace(new RegExp(escapedPhrase, "gi"), phrase);
+  }, title);
+}
+
+export function formatApaThesisTitle(value: unknown) {
+  const normalized =
+    typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+  if (!normalized) {
+    return "";
+  }
+
+  const words = normalized.split(" ");
+  let capitalizeNext = true;
+
+  const formatted = words.map((word, index) => {
+    const match = word.match(WORD_PART_PATTERN);
+    if (!match) {
+      return word;
+    }
+
+    const [, prefix = "", core = "", suffix = ""] = match;
+    if (!core) {
+      capitalizeNext = SUBTITLE_SEPARATOR_PATTERN.test(word);
+      return word;
+    }
+
+    const isLastWord = index === words.length - 1;
+    const formattedCore = formatWordCore(core, capitalizeNext, isLastWord);
+    capitalizeNext = SUBTITLE_SEPARATOR_PATTERN.test(`${core}${suffix}`);
+
+    return `${prefix}${formattedCore}${suffix}`;
+  });
+
+  return restoreProtectedPhrases(formatted.join(" "));
+}

--- a/src/utils/thesis_title.ts
+++ b/src/utils/thesis_title.ts
@@ -81,7 +81,7 @@ function formatWordCore(core: string, forceCapitalize: boolean, isLastWord: bool
 
   const parts = core.split("-");
   return parts
-    .map((part, index) => {
+    .map((part) => {
       if (!part) {
         return part;
       }
@@ -98,8 +98,7 @@ function formatWordCore(core: string, forceCapitalize: boolean, isLastWord: bool
       const shouldCapitalize =
         forceCapitalize ||
         isLastWord ||
-        !MINOR_WORDS.has(part.toLowerCase()) ||
-        index > 0;
+        !MINOR_WORDS.has(part.toLowerCase());
 
       return shouldCapitalize ? capitalizeWord(part) : part.toLowerCase();
     })

--- a/tests/thesis_title.test.cjs
+++ b/tests/thesis_title.test.cjs
@@ -39,3 +39,10 @@ test("trims and collapses repeated whitespace", () => {
     "Effects of COVID-19 on ICT Students",
   );
 });
+
+test("keeps minor words lowercase inside hyphenated compounds", () => {
+  assert.equal(
+    formatApaThesisTitle("a state-of-the-art learning system"),
+    "A State-of-the-Art Learning System",
+  );
+});

--- a/tests/thesis_title.test.cjs
+++ b/tests/thesis_title.test.cjs
@@ -1,0 +1,41 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { formatApaThesisTitle } = require("../dist/utils/thesis_title.js");
+
+test("formats an uppercase thesis title and preserves a geographic name", () => {
+  assert.equal(
+    formatApaThesisTitle(
+      "THE IMPACT OF BULLYING: A CASE STUDY AT SANTO TOMAS, DAVAO DEL NORTE",
+    ),
+    "The Impact of Bullying: A Case Study at Santo Tomas, Davao del Norte",
+  );
+});
+
+test("lowercases APA minor words", () => {
+  assert.equal(
+    formatApaThesisTitle("an analysis of teaching and learning in schools"),
+    "An Analysis of Teaching and Learning in Schools",
+  );
+});
+
+test("capitalizes the first word after a subtitle separator", () => {
+  assert.equal(
+    formatApaThesisTitle("from data to decisions: the role of ai"),
+    "From Data to Decisions: The Role of AI",
+  );
+});
+
+test("preserves configured acronyms and intentional mixed case", () => {
+  assert.equal(
+    formatApaThesisTitle("the use of AI in eHealth systems"),
+    "The Use of AI in eHealth Systems",
+  );
+});
+
+test("trims and collapses repeated whitespace", () => {
+  assert.equal(
+    formatApaThesisTitle("  effects   of covid-19 on ict students  "),
+    "Effects of COVID-19 on ICT Students",
+  );
+});


### PR DESCRIPTION
## Summary
- add a reusable APA-style thesis-title formatter
- preserve configured acronyms, intentional mixed case, and proper-name phrases such as `Davao del Norte`
- enforce canonical titles during student registration and admin edits
- expose a title-preview endpoint
- add focused formatter tests and a dry-run-by-default existing-record backfill command

## Validation
- `npm run build`
- `npm run test:title-case`

## Tracking
Addresses auriumi/aurium-api#87. This draft must be reviewed by Koi before merge. It does not modify residential address fields.