### PR TITLE
Fix controller fall-through after error responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "nodemon",
     "build": "tsc",
+    "test": "npm run build && node --test tests/controller_responses.test.cjs",
     "start": "node dist/index.js"
   },
   "keywords": [],

--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -69,7 +69,7 @@ export async function getStaffDetails(req: AdminRequest, res: Response) {
 
   } catch (err) {
     console.error("Error: ", err);
-    res.status(500).json({
+    return res.status(500).json({
       status: 'Internal Server Error'
     });
   }
@@ -101,13 +101,13 @@ export async function handleVerify(req: AdminRequest, res: Response) {
       });
     }
 
-    res.json({
+    return res.json({
       status: "Success!"
     });
 
   } catch (err) {
     console.error("Error: ", err);
-    res.status(500).json({
+    return res.status(500).json({
       status: 'Internal Server Error'
     });
   }
@@ -138,13 +138,13 @@ export async function handleCancel(req: AdminRequest, res: Response) {
       });
     }
 
-    res.json({
+    return res.json({
       status: "Success!"
     });
 
   } catch (err) {
     console.error("Error: ", err);
-    res.status(500).json({
+    return res.status(500).json({
       status: 'Internal Server Error'
     });
   }
@@ -154,18 +154,18 @@ export async function handleCancel(req: AdminRequest, res: Response) {
 export async function fetchUnverifiedStudents(req: Request, res: Response) {
   try {
     const { page } = req.query;
-    if (!page) res.status(400).json({ error: 'Invalid request' });
+    if (!page) return res.status(400).json({ error: 'Invalid request' });
 
     const total = await adminService.getUnverifiedStudentCount();
     const student_list = await adminService.gethUnverifiedStudents(Number(page));
 
-    res.json({
+    return res.json({
       total,
       student_list
     });
   } catch (err) {
     console.error("Error: ", err);
-    res.status(500).json({
+    return res.status(500).json({
       status: 'Internal Server Error'
     });
   }
@@ -177,13 +177,13 @@ export async function searchUnverifiedById(req: Request, res: Response) {
     if (!id) return res.status(400).json({ error: 'Invalid request' });
 
     const result = await adminService.getUnverifiedStudentById(Number(id));  
-    if (!result.success) res.status(404).json({ reason: result.reason });
+    if (!result.success) return res.status(404).json({ reason: result.reason });
 
-    res.json(result.student);
+    return res.json(result.student);
 
   } catch (err) {
     console.error("Error: ", err);
-    res.status(500).json({
+    return res.status(500).json({
       status: 'Internal Server Error'
     });
   }
@@ -196,12 +196,12 @@ export async function addSchedule(req: Request, res: Response) {
     const success = await adminService.addSchedule(body.date, body.am_cap, body.pm_cap);
 
     if (!success) {
-      res.status(400).json({
+      return res.status(400).json({
         status: 'failed'
       });
     } 
 
-    res.json({
+    return res.json({
       status: 'success'
     });
 
@@ -223,7 +223,7 @@ export async function addSchedule(req: Request, res: Response) {
     }
 
     console.error("Server error: ", err);
-    res.status(500).json({
+    return res.status(500).json({
       status: 'Internal Server Error'
     });
   }
@@ -241,7 +241,7 @@ export async function handleToggleScheduleState(req: AdminRequest, res: Response
 
   try {
     const result = await adminService.toggleScheduleState(Number(booking_id));
-    if (!result.success) res.status(404).json({ reason: result.reason });
+    if (!result.success) return res.status(404).json({ reason: result.reason });
 
     return res.json({ status: 'success' });
 
@@ -497,7 +497,7 @@ export async function handleStudentPasswordReset(req: AdminRequest, res: Respons
     });
   }
 
-  res.json({ status: 'success' });
+  return res.json({ status: 'success' });
 }
 
 export async function fetchStaffList(req: AdminRequest, res: Response) {

--- a/src/api/auth/auth_controller.ts
+++ b/src/api/auth/auth_controller.ts
@@ -59,7 +59,7 @@ export async function handleLogin(req: Request, res: Response) {
             path: '/'
         });
 
-        res.json({
+        return res.json({
             status: 'ok',
             is_new: result.is_new
         });
@@ -98,7 +98,7 @@ export async function handleLogout(req: Request, res: Response) {
         path: '/'
     });
 
-    res.status(200).json({
+    return res.status(200).json({
         status: "ok"
     });
 }

--- a/src/api/student/student_controller.ts
+++ b/src/api/student/student_controller.ts
@@ -40,14 +40,14 @@ export async function getStudentById(req: StudentRequest, res: Response) {
         //get id from jwt paylaod
         const student_number = req.user?.student_number;
         if (!student_number) {
-            res.status(404).json({ error: "Invalid request!"});
+            return res.status(404).json({ error: "Invalid request!"});
         }
 
-        const result = await studentService.getStudentProfile(parseInt(student_number!));
+        const result = await studentService.getStudentProfile(parseInt(student_number));
         if (!result.success) {
-            res.status(404).json({ error: result.reason });
+            return res.status(404).json({ error: result.reason });
         }
-        res.json(result.student);
+        return res.json(result.student);
 
     } catch (err) {
         console.error("Error: ", err);
@@ -147,9 +147,9 @@ export async function getPhotoUploadUrl(req: StudentRequest, res: Response) {
 
     try {
         const { upload_url, photo_url } = await generatePresignedUrl(student_number, ext, mime);
-        res.json({ upload_url, photo_url });
+        return res.json({ upload_url, photo_url });
     } catch (err) {
-        res.status(500).json({ error: "Something went wrong generating URL" })
+        return res.status(500).json({ error: "Something went wrong generating URL" })
     }
 }
 
@@ -176,7 +176,7 @@ export async function savePhotoUrl(req: StudentRequest, res: Response) {
         return res.json({ sucess: true });
 
     } catch {
-        res.status(500).json({ error: "Something went wrong saving photo URL" });
+        return res.status(500).json({ error: "Something went wrong saving photo URL" });
     }
 }
 

--- a/tests/controller_responses.test.cjs
+++ b/tests/controller_responses.test.cjs
@@ -1,0 +1,143 @@
+const assert = require("node:assert/strict");
+const { afterEach, mock, test } = require("node:test");
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@localhost:5432/aurium_test";
+process.env.RESEND_API ??= "test";
+
+const adminService = require("../dist/api/admin/admin_service.js");
+const adminController = require("../dist/api/admin/admin_controller.js");
+const studentService = require("../dist/api/student/student_service.js");
+const studentController = require("../dist/api/student/student_controller.js");
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+function createResponse() {
+  const calls = [];
+  const response = {
+    status(code) {
+      calls.push({ type: "status", code });
+      return response;
+    },
+    json(body) {
+      calls.push({ type: "json", body });
+      return response;
+    },
+  };
+
+  return { calls, response };
+}
+
+function jsonCalls(calls) {
+  return calls.filter((call) => call.type === "json");
+}
+
+test("fetchUnverifiedStudents returns after a missing page query", async () => {
+  const count = mock.method(adminService, "getUnverifiedStudentCount", async () => 1);
+  const fetch = mock.method(adminService, "gethUnverifiedStudents", async () => []);
+  const { calls, response } = createResponse();
+
+  await adminController.fetchUnverifiedStudents({ query: {} }, response);
+
+  assert.deepEqual(calls, [
+    { type: "status", code: 400 },
+    { type: "json", body: { error: "Invalid request" } },
+  ]);
+  assert.equal(count.mock.callCount(), 0);
+  assert.equal(fetch.mock.callCount(), 0);
+});
+
+test("searchUnverifiedById sends only the missing-record response", async () => {
+  const search = mock.method(
+    adminService,
+    "getUnverifiedStudentById",
+    async () => ({ success: false, reason: "Student not found" }),
+  );
+  const { calls, response } = createResponse();
+
+  await adminController.searchUnverifiedById(
+    { params: { id: "20260001" } },
+    response,
+  );
+
+  assert.equal(search.mock.callCount(), 1);
+  assert.deepEqual(calls, [
+    { type: "status", code: 404 },
+    { type: "json", body: { reason: "Student not found" } },
+  ]);
+});
+
+test("addSchedule returns after a rejected service operation", async () => {
+  const add = mock.method(adminService, "addSchedule", async () => false);
+  const { calls, response } = createResponse();
+
+  await adminController.addSchedule(
+    { body: { date: "2026-07-01", am_cap: 10, pm_cap: 10 } },
+    response,
+  );
+
+  assert.equal(add.mock.callCount(), 1);
+  assert.deepEqual(calls, [
+    { type: "status", code: 400 },
+    { type: "json", body: { status: "failed" } },
+  ]);
+});
+
+test("handleToggleScheduleState sends only the failed-service response", async () => {
+  const toggle = mock.method(
+    adminService,
+    "toggleScheduleState",
+    async () => ({ success: false, reason: "Schedule not found" }),
+  );
+  const { calls, response } = createResponse();
+
+  await adminController.handleToggleScheduleState(
+    { query: { id: "9" } },
+    response,
+  );
+
+  assert.equal(toggle.mock.callCount(), 1);
+  assert.deepEqual(calls, [
+    { type: "status", code: 404 },
+    { type: "json", body: { reason: "Schedule not found" } },
+  ]);
+});
+
+test("getStudentById returns before profile lookup when identity is missing", async () => {
+  const lookup = mock.method(
+    studentService,
+    "getStudentProfile",
+    async () => ({ success: true, student: {} }),
+  );
+  const { calls, response } = createResponse();
+
+  await studentController.getStudentById({}, response);
+
+  assert.equal(lookup.mock.callCount(), 0);
+  assert.deepEqual(calls, [
+    { type: "status", code: 404 },
+    { type: "json", body: { error: "Invalid request!" } },
+  ]);
+});
+
+test("getStudentById sends only the missing-profile response", async () => {
+  const lookup = mock.method(
+    studentService,
+    "getStudentProfile",
+    async () => ({ success: false, reason: "Student doesn't exist!" }),
+  );
+  const { calls, response } = createResponse();
+
+  await studentController.getStudentById(
+    { user: { student_number: "20260001" } },
+    response,
+  );
+
+  assert.equal(lookup.mock.callCount(), 1);
+  assert.equal(jsonCalls(calls).length, 1);
+  assert.deepEqual(calls, [
+    { type: "status", code: 404 },
+    { type: "json", body: { error: "Student doesn't exist!" } },
+  ]);
+});


### PR DESCRIPTION
## Issue fixed

Closes #83 - Stop controller execution after sending error responses.

## Summary of changes

- Return immediately from validation, missing-record, and failed-service response paths.
- Apply explicit terminal returns consistently across admin, student, and auth controllers.
- Prevent downstream service calls after invalid requests.
- Add regression coverage that verifies each affected path sends exactly one response.

## Files changed

- `src/api/admin/admin_controller.ts`
- `src/api/student/student_controller.ts`
- `src/api/auth/auth_controller.ts`
- `tests/controller_responses.test.cjs`
- `package.json`

## How it was tested

- `npm test` - builds the TypeScript project and runs 6 controller regression tests.
- `git diff --check`
- Audited all controller JSON responses to confirm they return explicitly.

## Remaining notes

- Existing response payloads and status codes were preserved to avoid changing frontend contracts.
- No database schema or environment configuration changes are required.