### PR TITLE
Align admin rate limits with queue polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ Here are the key tools and libraries used in this project:
 **[Node.js](https://nodejs.org/)**: Provides the JavaScript runtime environment to run the backend application.
 
 **[Bcrypt](https://github.com/kelektiv/node.bcrypt.js)**: Secures user passwords by hashing them before saving to the database, ensuring password security.
+
+## Rate-limit budgets
+
+Rate limits use a three-minute window unless noted otherwise:
+
+- `GET /api/admin/queue/list`: 90 requests. The queue loads immediately and
+  polls every five seconds, producing 37 requests in a full window. This budget
+  supports two active queue displays with additional headroom.
+- Other admin `GET` and `HEAD` requests: 120 requests.
+- Admin mutation requests (`POST`, `PATCH`, `PUT`, and `DELETE`): 50 requests.
+- Authentication endpoints: 5 requests per five minutes.
+
+Queue polling, other admin reads, and admin mutations use separate counters, so
+background queue refreshes do not consume the budget for operational changes.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "nodemon",
     "build": "tsc",
+    "test": "npm run build && node --test tests/rate_limits.test.cjs",
     "start": "node dist/index.js"
   },
   "keywords": [],

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,15 @@ import authRoutes from "./api/auth/auth_route";
 
 const app = express();
 
+const ADMIN_RATE_LIMIT_WINDOW_MS = 3 * 60 * 1000;
+
+export const ADMIN_RATE_LIMITS = {
+  windowMs: ADMIN_RATE_LIMIT_WINDOW_MS,
+  queuePolls: 90,
+  reads: 120,
+  mutations: 50,
+} as const;
+
 const corsConfig = {
   origin: process.env.NODE_ENV == "production"
     ? "https://aurium-yearbook.site" //production
@@ -31,11 +40,30 @@ const login_limiter = rateLimit({
   legacyHeaders: false
 });
 
-const admin_limiter = rateLimit({
-  windowMs: 3 * 60 * 1000, //3 mins
-  limit: 50,
-  message: "Too many request, please try again later :P",
-  legacyHeaders: false
+const queue_poll_limiter = rateLimit({
+  windowMs: ADMIN_RATE_LIMITS.windowMs,
+  limit: ADMIN_RATE_LIMITS.queuePolls,
+  message: "Too many queue refresh requests, please try again later",
+  legacyHeaders: false,
+});
+
+const admin_read_limiter = rateLimit({
+  windowMs: ADMIN_RATE_LIMITS.windowMs,
+  limit: ADMIN_RATE_LIMITS.reads,
+  message: "Too many admin read requests, please try again later",
+  legacyHeaders: false,
+  skip: (req) => (
+    (req.method !== "GET" && req.method !== "HEAD")
+    || req.path === "/queue/list"
+  ),
+});
+
+const admin_mutation_limiter = rateLimit({
+  windowMs: ADMIN_RATE_LIMITS.windowMs,
+  limit: ADMIN_RATE_LIMITS.mutations,
+  message: "Too many admin changes, please try again later",
+  legacyHeaders: false,
+  skip: (req) => req.method === "GET" || req.method === "HEAD",
 });
 
 const gen_limiter = rateLimit({
@@ -46,7 +74,15 @@ const gen_limiter = rateLimit({
 });
 
 //API ROUTES
-app.use("/api/admin", admin_limiter, verifyToken, isAdmin, adminRoutes);
+app.use("/api/admin/queue/list", queue_poll_limiter);
+app.use(
+  "/api/admin",
+  admin_read_limiter,
+  admin_mutation_limiter,
+  verifyToken,
+  isAdmin,
+  adminRoutes,
+);
 app.use("/api/student", gen_limiter, verifyToken, studentRoutes);
 app.use("/api/auth", login_limiter, authRoutes);
 

--- a/tests/rate_limits.test.cjs
+++ b/tests/rate_limits.test.cjs
@@ -1,0 +1,112 @@
+const assert = require("node:assert/strict");
+const { after, before, test } = require("node:test");
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@localhost:5432/aurium_test";
+process.env.JWT_SAUCE ??= "test-secret";
+process.env.RESEND_API ??= "test";
+process.env.R2_ACC_ID ??= "test";
+process.env.R2_ACC_KEY ??= "test";
+process.env.R2_SECRET_KEY ??= "test";
+
+const {
+  ADMIN_RATE_LIMITS,
+  default: app,
+} = require("../dist/server.js");
+
+let baseUrl;
+let server;
+
+before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+});
+
+async function request(path, options) {
+  const response = await fetch(`${baseUrl}${path}`, options);
+  await response.text();
+  return response;
+}
+
+test("a full three-minute queue polling cycle does not hit the limiter", async () => {
+  const pollIntervalMs = 5_000;
+  const expectedRequests = Math.floor(
+    ADMIN_RATE_LIMITS.windowMs / pollIntervalMs,
+  ) + 1;
+
+  assert.equal(expectedRequests, 37);
+  assert.ok(expectedRequests < ADMIN_RATE_LIMITS.queuePolls);
+
+  for (let requestNumber = 1; requestNumber <= expectedRequests; requestNumber += 1) {
+    const response = await request("/api/admin/queue/list?period=AM");
+
+    assert.equal(
+      response.status,
+      401,
+      `queue request ${requestNumber} was unexpectedly rate limited`,
+    );
+  }
+});
+
+test("queue polling does not consume the other admin read budget", async () => {
+  for (
+    let requestNumber = 1;
+    requestNumber <= ADMIN_RATE_LIMITS.reads;
+    requestNumber += 1
+  ) {
+    const response = await request("/api/admin/profile");
+
+    assert.equal(
+      response.status,
+      401,
+      `admin read ${requestNumber} was rate limited too early`,
+    );
+  }
+
+  const limitedResponse = await request("/api/admin/profile");
+  assert.equal(limitedResponse.status, 429);
+});
+
+test("queue polling does not consume the admin mutation budget", async () => {
+  for (
+    let requestNumber = 1;
+    requestNumber <= ADMIN_RATE_LIMITS.mutations;
+    requestNumber += 1
+  ) {
+    const response = await request("/api/admin/book/add", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: "{}",
+    });
+
+    assert.equal(
+      response.status,
+      401,
+      `mutation request ${requestNumber} was rate limited too early`,
+    );
+  }
+
+  const limitedResponse = await request("/api/admin/book/add", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: "{}",
+  });
+
+  assert.equal(limitedResponse.status, 429);
+});


### PR DESCRIPTION
## Issue fixed

Closes #84 - Align rate limits with queue polling and normal admin traffic.

## Summary of changes

- Give `GET /api/admin/queue/list` a dedicated 90-request, three-minute polling budget.
- Give other admin reads a separate 120-request budget.
- Preserve the stricter 50-request budget for admin mutations and the existing authentication limit.
- Prevent queue refreshes from consuming dashboard-read or mutation capacity.
- Document the expected five-second polling frequency and rate-limit headroom.
- Add load-style regression tests for queue polling and independent limiter buckets.

## Files changed

- `src/server.ts`
- `tests/rate_limits.test.cjs`
- `package.json`
- `README.md`

## How it was tested

- `npm test` - runs the TypeScript build and 3 rate-limit integration tests.
- Verified all 37 requests from a full three-minute, five-second polling cycle avoid `429` responses.
- Verified the separate 120-request admin-read and 50-request mutation budgets remain available after queue polling.
- `git diff --check`

## Remaining notes

- Rate limits remain IP-based, matching the existing application behavior.
- No frontend, database schema, or environment configuration changes are required.