### PR TITLE
feat: search-based query for image management

### DIFF
--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -618,7 +618,7 @@ export async function saveImageUrl(req: AdminRequest, res: Response) {
 
 const VALID_APPROVAL_VIEWS = new Set(["PENDING", "RESOLVED", "ALL"]);
 
-//review queue (approvers only)
+//review queue
 export async function fetchImageApprovals(req: Request, res: Response) {
   try {
     const page = Number(req.query.page ?? 1);

--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -529,6 +529,7 @@ function parseImageYear(raw: unknown): number | null {
 //list students with their graduation/theme image status for a year
 export async function fetchImageStudents(req: Request, res: Response) {
   try {
+    const id = Number(req.query.id); 
     const page = Number(req.query.page ?? 1);
     const dept = String(req.query.dept ?? "ALL");
     const course = String(req.query.course ?? "ALL");
@@ -541,7 +542,7 @@ export async function fetchImageStudents(req: Request, res: Response) {
     const missingRaw = String(req.query.missing ?? "ALL").toUpperCase();
     const missing = VALID_MISSING.has(missingRaw) ? missingRaw : "ALL";
 
-    const result = await adminService.img_queryStudents(page, dept, course, major, status, year, missing);
+    const result = await adminService.img_queryStudents(id, page, dept, course, major, status, year, missing);
     return res.json(result);
   } catch (err) {
     console.error("Server error: ", err);

--- a/src/api/admin/admin_route.ts
+++ b/src/api/admin/admin_route.ts
@@ -60,7 +60,7 @@ router.get("/images/get-upload", requirePermission(Permission.IMAGE_UPLOAD), adm
 router.post("/images/save", requirePermission(Permission.IMAGE_UPLOAD), adminController.saveImageUrl);
 
 // image approval forum
-router.get("/images/approvals", requirePermission(Permission.IMAGE_APPROVE), requireImageApprover, adminController.fetchImageApprovals);
+router.get("/images/approvals", requirePermission(Permission.IMAGE_APPROVE), adminController.fetchImageApprovals);
 router.patch("/images/:id/status", requirePermission(Permission.IMAGE_APPROVE), requireImageApprover, adminController.handleImageDecision);
 router.get("/images/:id/comments", requirePermission(Permission.IMAGE_VIEW), adminController.fetchImageThread);
 router.post("/images/:id/comments", requirePermission(Permission.IMAGE_VIEW), adminController.handleAddImageComment);

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -590,6 +590,7 @@ export async function img_getUploadUrl(
 // paginated students with their graduation/theme image status for a given year,
 // filterable by dept/course/major/student status + missing-image scope
 export async function img_queryStudents(
+  id: number,
   page: number,
   dept: string,
   course: string,
@@ -602,35 +603,40 @@ export async function img_queryStudents(
   const skip = (safe_page - 1) * I_STUDENTS_PER_PAGE;
 
   const where: any = {};
-  if (dept !== "ALL") where.department = dept;
-  if (course !== "ALL") where.course = course;
-  if (major !== "ALL") where.major = major;
+  
+  //if no id provided then run query as usual otherwise ignore filters <3
+  if (!id) {
+    if (dept !== "ALL") where.department = dept;
+    if (course !== "ALL") where.course = course;
+    if (major !== "ALL") where.major = major;
+    if (status !== "ALL") {
+      const status_map = STATUS_MAP[Number(status)];
+      if (status_map) where.studentAuth = { status: status_map };
+    }
 
-  if (status !== "ALL") {
-    const status_map = STATUS_MAP[Number(status)];
-    if (status_map) where.studentAuth = { status: status_map };
-  }
+    // image-presence filter, scoped to the selected year
+    const gradNone = { images: { none: { type: ImageType.GRADUATION, year } } };
+    const themeNone = { images: { none: { type: ImageType.THEME, year } } };
+    const gradSome = { images: { some: { type: ImageType.GRADUATION, year } } };
+    const themeSome = { images: { some: { type: ImageType.THEME, year } } };
 
-  // image-presence filter, scoped to the selected year
-  const gradNone = { images: { none: { type: ImageType.GRADUATION, year } } };
-  const themeNone = { images: { none: { type: ImageType.THEME, year } } };
-  const gradSome = { images: { some: { type: ImageType.GRADUATION, year } } };
-  const themeSome = { images: { some: { type: ImageType.THEME, year } } };
-
-  switch (missing) {
-    case "GRADUATION":
-      where.images = { none: { type: ImageType.GRADUATION, year } };
-      break;
-    case "THEME":
-      where.images = { none: { type: ImageType.THEME, year } };
-      break;
-    case "BOTH":
-      where.AND = [gradNone, themeNone];
-      break;
-    case "NONE": // has both already
-      where.AND = [gradSome, themeSome];
-      break;
-    // "ALL" -> no image filter
+    switch (missing) {
+      case "GRADUATION":
+        where.images = { none: { type: ImageType.GRADUATION, year } };
+        break;
+      case "THEME":
+        where.images = { none: { type: ImageType.THEME, year } };
+        break;
+      case "BOTH":
+        where.AND = [gradNone, themeNone];
+        break;
+      case "NONE": // has both already
+        where.AND = [gradSome, themeSome];
+        break;
+      // "ALL" -> no image filter
+    }
+  } else {
+    where.student_number = id;
   }
 
   const total_students = await prisma.student.count();


### PR DESCRIPTION
This pull request updates the student image query and approval logic to support searching by student ID and simplifies approval route permissions. The main changes include adding an ID-based student search, adjusting how filters are applied, and removing an unnecessary middleware from the image approvals route.

**Student image query improvements:**

* Added an `id` parameter to the `fetchImageStudents` controller and the `img_queryStudents` service method, allowing queries for a specific student by their student number. If an ID is provided, all other filters are ignored.
**Image approvals route changes:**

* Removed the `requireImageApprover` middleware from the `/images/approvals` GET route, so only the `IMAGE_APPROVE` permission is required to access image approvals.
* Updated the comment on the `fetchImageApprovals` controller to reflect that the route is no longer limited to approvers only.