### PR TITLE
Secure image uploads and enforce booking capacity

### DIFF
--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import * as adminService from "./admin_service";
 import * as notificationService from "./notification_service";
 import { Prisma } from "@prisma/client";
+import { isManagedYearbookImageUrl, normalizeImageUploadMeta } from "../student/r2_service";
 
 interface AdminRequest extends Request {
   user?: {
@@ -565,12 +566,14 @@ export async function getImageUploadUrl(req: Request, res: Response) {
   const year = parseImageYear(req.query.year);
   if (year === null) return res.status(400).json({ reason: "Invalid year." });
 
-  const ext = String(req.query.ext ?? "jpg");
-  const mime = String(req.query.mime ?? "image/jpeg");
+  const uploadMeta = normalizeImageUploadMeta(req.query.ext, req.query.mime);
+  if (!uploadMeta) {
+    return res.status(400).json({ reason: "Only JPG, PNG, and WEBP image uploads are allowed." });
+  }
 
   try {
     const { upload_url, photo_url } = await adminService.img_getUploadUrl(
-      student_number, type as "GRADUATION" | "THEME", year, ext, mime
+      student_number, type as "GRADUATION" | "THEME", year, uploadMeta.ext, uploadMeta.mime
     );
     return res.json({ upload_url, photo_url });
   } catch (err) {
@@ -598,7 +601,11 @@ export async function saveImageUrl(req: AdminRequest, res: Response) {
   const safeYear = parseImageYear(year);
   if (safeYear === null) return res.status(400).json({ reason: "Invalid year." });
 
-  if (typeof photo_url !== "string" || !photo_url.startsWith("https://")) {
+  if (
+    typeof photo_url !== "string" ||
+    !photo_url.startsWith("https://") ||
+    !isManagedYearbookImageUrl(photo_url, student_number, normalizedType as "GRADUATION" | "THEME", safeYear)
+  ) {
     return res.status(400).json({ reason: "Invalid photo URL." });
   }
 

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -381,6 +381,9 @@ export async function fetchSchedule() {
   return prisma.bookingDay.findMany({
     include: {
       bookings: {
+        orderBy: {
+          created_at: "asc",
+        },
         include: {
           student: {
             select: {

--- a/src/api/auth/auth_service.ts
+++ b/src/api/auth/auth_service.ts
@@ -4,25 +4,49 @@ import jwt from 'jsonwebtoken';
 import 'dotenv/config';
 
 const jwt_sauce = process.env.JWT_SAUCE;
+const TURNSTILE_TEST_SECRET = "1x0000000000000000000000000000000AA";
 
+function getTurnstileSecret() {
+    if (process.env.TURNSTILE_SECRET_KEY) {
+        return process.env.TURNSTILE_SECRET_KEY;
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+        return TURNSTILE_TEST_SECRET;
+    }
+
+    return null;
+}
 
 export async function verifyCaptcha(token: string): Promise<boolean> {
-    const secret = process.env.NODE_ENV === "development"
-        ? "1x0000000000000000000000000000000AA"
-        : process.env.TURNSTILE_SECRET_KEY!;
+    const secret = getTurnstileSecret();
+
+    if (!secret) {
+        console.error("TURNSTILE_SECRET_KEY is missing.");
+        return false;
+    }
+
+    if (process.env.NODE_ENV !== "production" && secret === TURNSTILE_TEST_SECRET) {
+        return true;
+    }
 
     const params = new URLSearchParams({
         secret,
         response: token,
     });
 
-    const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
-        method: "POST",
-        body: params,
-    });
+    try {
+        const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+            method: "POST",
+            body: params,
+        });
 
-    const data = await res.json() as { success: boolean };
-    return data.success;
+        const data = await res.json() as { success: boolean };
+        return data.success;
+    } catch (err) {
+        console.error("CAPTCHA verification request failed:", err);
+        return false;
+    }
 }
 
 export async function handleLogin(id: string, pass: string, is_admin?: boolean) {

--- a/src/api/auth/permissions.ts
+++ b/src/api/auth/permissions.ts
@@ -61,7 +61,7 @@ export const PERMISSION_MATRIX: Record<Permission, AdminRoles[]> = {
     [Permission.BOOKING_VIEW]: [ADMINISTRATOR, MODERATOR],
     [Permission.BOOKING_CREATE]: [ADMINISTRATOR],
     [Permission.BOOKING_TOGGLE]: [ADMINISTRATOR],
-    [Permission.BOOKING_UPDATE]: [ADMINISTRATOR],
+    [Permission.BOOKING_UPDATE]: [ADMINISTRATOR, MODERATOR],
 
     [Permission.STAFF_VIEW]: [ADMINISTRATOR],
     [Permission.STAFF_MANAGE_ROLE]: [ADMINISTRATOR],

--- a/src/api/student/r2_service.ts
+++ b/src/api/student/r2_service.ts
@@ -4,6 +4,11 @@ import prisma from "../../config/prisma";
 
 const ACC_ID = process.env.R2_ACC_ID;
 const BUCKET = "aurium";
+const IMAGE_MIME_EXTENSIONS: Record<string, string[]> = {
+    "image/jpeg": ["jpg", "jpeg"],
+    "image/png": ["png"],
+    "image/webp": ["webp"],
+};
 
 const s3 = new S3Client({
     region: "auto",
@@ -49,6 +54,21 @@ export async function generateImageUploadUrl(
     return { upload_url, photo_url };
 }
 
+export function normalizeImageUploadMeta(extRaw: unknown, mimeRaw: unknown) {
+    const ext = String(extRaw ?? "jpg").toLowerCase().replace(/^\./, "");
+    const mime = String(mimeRaw ?? "image/jpeg").toLowerCase();
+    const allowedExts = IMAGE_MIME_EXTENSIONS[mime];
+
+    if (!allowedExts || !allowedExts.includes(ext)) {
+        return null;
+    }
+
+    return {
+        ext: ext === "jpeg" ? "jpg" : ext,
+        mime,
+    };
+}
+
 function extractKey(photo_url: string): string | null {
     try {
         const { hostname, pathname } = new URL(photo_url);
@@ -63,12 +83,34 @@ function extractKey(photo_url: string): string | null {
     }
 }
 
+export function isManagedYearbookImageUrl(
+    photo_url: string,
+    student_number: number,
+    type: "GRADUATION" | "THEME",
+    year: number
+) {
+    const key = extractKey(photo_url);
+    if (!key) return false;
+
+    const folder = type === "GRADUATION" ? "graduation_photos" : "theme_photos";
+    const escapedStudentNumber = String(student_number).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const expected = new RegExp(`^${folder}/${year}/${escapedStudentNumber}\\.(jpg|jpeg|png|webp)$`);
+
+    return expected.test(key);
+}
+
 export async function generateReadUrl(photo_url: string | null): Promise<string | null> {
     if (!photo_url) return null;
     const key = extractKey(photo_url);
     if (!key) return null;
     const command = new GetObjectCommand({ Bucket: BUCKET, Key: key });
-    return getSignedUrl(s3, command, { expiresIn: 3600 });
+
+    try {
+        return await getSignedUrl(s3, command, { expiresIn: 3600 });
+    } catch (err) {
+        console.error("Unable to generate signed read URL:", err);
+        return null;
+    }
 }
 
 export async function uploadPhotoUrl(student_number: string, photo_url: string) {

--- a/src/api/student/student_controller.ts
+++ b/src/api/student/student_controller.ts
@@ -81,7 +81,12 @@ export async function createBooking(req: StudentRequest, res: Response) {
             })
         }
 
-        await studentService.createBooking(parseInt(student_number!), booking_id, period);
+        const result = await studentService.createBooking(parseInt(student_number!), Number(booking_id), period);
+        if (!result.success) {
+            return res.status(400).json({
+                error: result.reason,
+            });
+        }
 
         return res.json({
             status: "Success"
@@ -121,7 +126,12 @@ export async function updateBooking(req: StudentRequest, res: Response) {
             })
         }
 
-        await studentService.updateBooking(id, booking_day_id, period, student_number);
+        const result = await studentService.updateBooking(id, Number(booking_day_id), period, student_number);
+        if (!result.success) {
+            return res.status(400).json({
+                error: result.reason,
+            });
+        }
 
         return res.json({
             status: "Success"

--- a/src/api/student/student_service.ts
+++ b/src/api/student/student_service.ts
@@ -61,8 +61,13 @@ export async function fetchBooking() {
       max_afternoon_cap: true,
       max_morning_cap: true,
       bookings: {
+        orderBy: {
+          created_at: "asc",
+        },
         select: {
+          id: true,
           period: true,
+          created_at: true,
         }
       },
     }
@@ -83,42 +88,118 @@ export async function fetchBooking() {
   });
 }
 
+function isPastUtcDate(date: Date) {
+  const compareDate = new Date(date);
+  compareDate.setUTCHours(0, 0, 0, 0);
+
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  return compareDate < today;
+}
+
+async function validateBookingSlot(booking_day_id: number, period: string, excludeBookingId?: number) {
+  const bookingDay = await prisma.bookingDay.findUnique({
+    where: { id: booking_day_id },
+    select: {
+      id: true,
+      date: true,
+      is_open: true,
+      max_morning_cap: true,
+      max_afternoon_cap: true,
+    },
+  });
+
+  if (!bookingDay) return { success: false, reason: "Schedule date is not available." };
+  if (!bookingDay.is_open) return { success: false, reason: "This schedule date is already closed." };
+  if (isPastUtcDate(bookingDay.date)) return { success: false, reason: "This schedule date has already passed." };
+
+  const capacity = period === "AM" ? bookingDay.max_morning_cap : bookingDay.max_afternoon_cap;
+  if (capacity <= 0) return { success: false, reason: "This session is not open for booking." };
+
+  const booked = await prisma.booking.count({
+    where: {
+      booking_day_id,
+      period,
+      ...(excludeBookingId ? { NOT: { id: excludeBookingId } } : {}),
+    },
+  });
+
+  if (booked >= capacity) return { success: false, reason: "This session is already full." };
+
+  return { success: true };
+}
+
 export async function createBooking(student_id: number, booking_id: number, period: string) {
   try {
-    return await prisma.booking.create({
-      data: {
-        student_number: student_id,
-        booking_day_id: booking_id,
-        period: period
-      }
-    }),
-    prisma.studentAuth.update({
-      where: {
-        student_number: student_id
-      },
-      data: {
-        status: StudentStatus.BOOKED
-      }
+    const existingBooking = await prisma.booking.findFirst({
+      where: { student_number: student_id },
+      select: { id: true },
     });
+
+    if (existingBooking) {
+      return { success: false, reason: "You already have a booking." };
+    }
+
+    const slot = await validateBookingSlot(booking_id, period);
+    if (!slot.success) return slot;
+
+    await prisma.$transaction([
+      prisma.booking.create({
+        data: {
+          student_number: student_id,
+          booking_day_id: booking_id,
+          period,
+        },
+      }),
+      prisma.studentAuth.update({
+        where: {
+          student_number: student_id
+        },
+        data: {
+          status: StudentStatus.BOOKED
+        }
+      }),
+    ]);
+
+    return { success: true };
   } catch(err) {
     console.error("Error: ", err);
+    return { success: false, reason: "Something went wrong while booking your schedule." };
   }
 }
 
 export async function updateBooking(booking_id: string, booking_day_id: number, period: string, student_number: string) {
   try {
-    return await prisma.booking.update({
+    const bookingId = parseInt(booking_id);
+    const studentNumber = parseInt(student_number);
+
+    const existingBooking = await prisma.booking.findUnique({
+      where: { id: bookingId },
+      select: { id: true, student_number: true },
+    });
+
+    if (!existingBooking || existingBooking.student_number !== studentNumber) {
+      return { success: false, reason: "Booking not found." };
+    }
+
+    const slot = await validateBookingSlot(booking_day_id, period, bookingId);
+    if (!slot.success) return slot;
+
+    await prisma.booking.update({
       where: {
-        id: parseInt(booking_id),
-        student_number: parseInt(student_number)
+        id: bookingId,
       },
       data: {
-        booking_day_id: booking_day_id,
-        period: period
+        booking_day_id,
+        period,
       }
     });
+
+    return { success: true };
   } catch(err) {
     console.error("Error: ", err);
+    return { success: false, reason: "Something went wrong while updating your schedule." };
   }
 }
 
@@ -148,6 +229,18 @@ export async function getStudentProfile(student_number: number) {
             booking_day: {
               select: {
                 date: true,
+                max_morning_cap: true,
+                max_afternoon_cap: true,
+                bookings: {
+                  orderBy: {
+                    created_at: "asc",
+                  },
+                  select: {
+                    id: true,
+                    period: true,
+                    created_at: true,
+                  },
+                },
               },
             },
           },


### PR DESCRIPTION
## Summary
- Harden image upload handling by validating managed yearbook image URLs, supported image MIME types, file extensions, and upload metadata before issuing upload URLs.
- Make local development resilient when R2 signing credentials are missing so image list reads do not crash the admin UI.
- Enforce booking availability on the backend for create/update flows, including duplicate booking checks, closed/past schedule checks, and AM/PM capacity limits.
- Allow moderators to update booking capacity while preserving administrator-only creation/toggle controls.
- Improve local Turnstile handling so localhost development can use the Cloudflare test secret without failing on remote verification network issues.

## Backend Notes
- Existing AM/PM booking schema is preserved.
- Hourly behavior is supported by returning stable booking ordering and capacity data for frontend hour grouping.
- Booking create/update now returns structured failure reasons so the frontend can show clearer messages.
- R2 read URL failures are logged and fail softly for local environments with incomplete R2 credentials.

## Verification
- `npm run build` passed.
- Manual bad-password login probe returned `401` instead of the previous captcha-related `500`.
- Image upload validation rejects unsupported MIME/extension combinations.