### PR TITLE
Store graduation cohort for preregistration

### DIFF
--- a/prisma/migrations/20260720000000_add_graduation_cohort/migration.sql
+++ b/prisma/migrations/20260720000000_add_graduation_cohort/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Student" ADD COLUMN IF NOT EXISTS "graduating_year" INTEGER;
+ALTER TABLE "Student" ADD COLUMN IF NOT EXISTS "graduation_term" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,8 @@ model Student {
   department           String?
   course               String?
   major                String?
+  graduating_year      Int?
+  graduation_term      String?
   nickname             String?
   suffix               String?
   thesis_title         String?

--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -298,8 +298,10 @@ export async function fetchMasterlist(req: Request, res: Response) {
     const course = String(req.query.course ?? "ALL");
     const major = String(req.query.major ?? "ALL");
     const status = String(req.query.status ?? "ALL");
+    const graduatingYear = String(req.query.graduatingYear ?? "ALL");
+    const graduationTerm = String(req.query.graduationTerm ?? "ALL");
 
-    const result = await adminService.m_queryByFilter(page, dept, course, major, status);
+    const result = await adminService.m_queryByFilter(page, dept, course, major, status, graduatingYear, graduationTerm);
     return res.json(result);
 
   } catch (err) {
@@ -312,7 +314,7 @@ export async function fetchMasterlist(req: Request, res: Response) {
 
 const ALLOWED_STUDENT_COLS = new Set([
   "student_number", "first_name", "last_name", "mid_name", "nickname", "suffix",
-  "department", "course", "major", "thesis_title", "school_email", "personal_email", "created_at",
+  "department", "course", "major", "graduating_year", "graduation_term", "thesis_title", "school_email", "personal_email", "created_at",
 ]);
 const ALLOWED_DETAIL_COLS = new Set([
   "birth_date", "province", "city", "barangay",
@@ -326,11 +328,13 @@ export async function exportMasterlist(req: Request, res: Response) {
     const course = String(req.query.course ?? "ALL");
     const major = String(req.query.major ?? "ALL");
     const status = String(req.query.status ?? "ALL");
+    const graduatingYear = String(req.query.graduatingYear ?? "ALL");
+    const graduationTerm = String(req.query.graduationTerm ?? "ALL");
 
     const rawCols = String(req.query.columns ?? "");
     const cols = rawCols.split(",").map(c => c.trim()).filter(Boolean);
 
-    const students = await adminService.m_exportAll(dept, course, major, status);
+    const students = await adminService.m_exportAll(dept, course, major, status, graduatingYear, graduationTerm);
 
     const rows = students.map(s => {
       const row: Record<string, any> = {};

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -36,6 +36,8 @@ const STUDENT_PERSONAL_FIELDS = new Set([
 const STUDENT_ACADEMIC_FIELDS = new Set([
   "course",
   "major",
+  "graduating_year",
+  "graduation_term",
   "thesis"
 ]);
 
@@ -489,7 +491,20 @@ export async function updateScheduleCapacity(id: number, session: string, new_ca
   }
 }
 
-export async function m_queryByFilter(page: number, dept: string, course: string, major: string, status: string) {
+function applyGraduationFilters(where: any, graduatingYear: string, graduationTerm: string) {
+  if (graduatingYear !== "ALL") {
+    const safeYear = Number(graduatingYear);
+    if (Number.isInteger(safeYear)) {
+      where.graduating_year = safeYear;
+    }
+  }
+
+  if (graduationTerm !== "ALL") {
+    where.graduation_term = graduationTerm;
+  }
+}
+
+export async function m_queryByFilter(page: number, dept: string, course: string, major: string, status: string, graduatingYear: string, graduationTerm: string) {
   const safe_page = page > 0 ? page : 1;
   const skip = (safe_page - 1) * M_STUDENTS_PER_PAGE;
 
@@ -497,6 +512,7 @@ export async function m_queryByFilter(page: number, dept: string, course: string
   if (dept !== "ALL") where.department = dept;
   if (course !== "ALL") where.course = course;
   if (major !== "ALL") where.major = major;
+  applyGraduationFilters(where, graduatingYear, graduationTerm);
 
   if (status !== "ALL") {
     const status_map = STATUS_MAP[Number(status)];
@@ -556,11 +572,12 @@ export async function m_queryById(student_id: number) {
   return { success: true, student };
 }
 
-export async function m_exportAll(dept: string, course: string, major: string, status: string) {
+export async function m_exportAll(dept: string, course: string, major: string, status: string, graduatingYear: string, graduationTerm: string) {
   const where: any = {};
   if (dept !== "ALL") where.department = dept;
   if (course !== "ALL") where.course = course;
   if (major !== "ALL") where.major = major;
+  applyGraduationFilters(where, graduatingYear, graduationTerm);
 
   if (status !== "ALL") {
     const status_map = STATUS_MAP[Number(status)];
@@ -1255,7 +1272,7 @@ export async function fv_updateStudent(studentId: number, type: string, data: an
       const studentData: Record<string, any> = {};
       for (const [key, value] of payloadEntries) {
         const fieldKey = key === "thesis" ? "thesis_title" : key;
-        studentData[fieldKey] = value;
+        studentData[fieldKey] = fieldKey === "graduating_year" ? Number(value) : value;
       }
 
       await prisma.student.update({

--- a/src/api/student/student_service.ts
+++ b/src/api/student/student_service.ts
@@ -8,7 +8,23 @@ type SolicitationPayload = {
   name: string;
 };
 
+const DEFAULT_GRADUATING_YEAR = 2026;
+const DEFAULT_GRADUATION_TERM = "YEAR_END";
+const ALLOWED_GRADUATION_TERMS = new Set(["MIDYEAR", "YEAR_END"]);
+
+function normalizeGraduatingYear(value: unknown) {
+  const year = Number(value);
+  return Number.isInteger(year) ? year : DEFAULT_GRADUATING_YEAR;
+}
+
+function normalizeGraduationTerm(value: unknown) {
+  const term = typeof value === "string" ? value.trim().toUpperCase() : "";
+  return ALLOWED_GRADUATION_TERMS.has(term) ? term : DEFAULT_GRADUATION_TERM;
+}
+
 export async function createStudent(body: any) {
+  const academics = body.academics ?? {};
+
   return await prisma.student.create({
     data: {
       student_number: parseInt(body.id),
@@ -17,12 +33,14 @@ export async function createStudent(body: any) {
       mid_name: body.middle_name,
       school_email: body.school_email,
       personal_email: body.personal_email,
-      department: body.academics.department,
-      course: body.academics.course,
-      major: body.academics.major,
+      department: academics.department,
+      course: academics.course,
+      major: academics.major,
+      graduating_year: normalizeGraduatingYear(academics.graduating_year ?? body.graduating_year),
+      graduation_term: normalizeGraduationTerm(academics.graduation_term ?? body.graduation_term),
       nickname: body.nickname,
       suffix: body.suffix,
-      thesis_title: body.academics.thesis,      
+      thesis_title: academics.thesis,
 
       studentDetail: {
         create: {

--- a/src/script/auto_reg.ts
+++ b/src/script/auto_reg.ts
@@ -39,6 +39,8 @@ function generateStudent(i: number) {
             department: "DEPARTMENT OF COMPUTING EDUCATION",
             course: "BACHELOR OF SCIENCE IN INFORMATION TECHNOLOGY",
             major: "N/A",
+            graduating_year: 2026,
+            graduation_term: "YEAR_END",
             thesis: randomItem(theses),
         },
         guardian: {


### PR DESCRIPTION
## Summary
- Add nullable Student.graduating_year and Student.graduation_term fields with a migration.
- Persist graduation cohort answers during student pre-registration with 2026 / Year End defaults for older clients.
- Add graduating year and term filters to masterlist queries and exports.
- Update local auto-registration script payloads.

## Testing
- npm exec prisma generate
- npm run build
- git diff --check