### PR TITLE
feat: grad year and term tracking

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,9 @@ model Student {
   updated_at           DateTime               @updatedAt
   created_at           DateTime               @default(now())
   student_number       Int                    @unique
+  grad_year            Int                    @default(2026)
+  grad_term            GraduationTerm         @default(MID_YEAR)
+
   studentAuth          StudentAuth?
   studentDetail        StudentDetail?
   studentSolicitations StudentSolicitations[]
@@ -30,6 +33,11 @@ model Student {
   attendanceQueue      AttendanceQueue?
   logs                 Logs[]
   images               StudentImage[]
+}
+
+enum GraduationTerm {
+  MID_YEAR
+  END_YEAR
 }
 
 model StudentDetail {

--- a/src/api/student/student_service.ts
+++ b/src/api/student/student_service.ts
@@ -8,6 +8,7 @@ type SolicitationPayload = {
   name: string;
 };
 
+//TODO: still unsafe, need data sanitation so we pray for now :D
 export async function createStudent(body: any) {
   return await prisma.student.create({
     data: {
@@ -23,6 +24,8 @@ export async function createStudent(body: any) {
       nickname: body.nickname,
       suffix: body.suffix,
       thesis_title: body.academics.thesis,      
+      grad_term: body.grad_term,
+      grad_year: body.grad_year,
 
       studentDetail: {
         create: {


### PR DESCRIPTION
This pull request introduces graduation year and term tracking for students, updates the Prisma schema accordingly, and ensures that the API supports these new fields when creating a student. The main changes are grouped below:

**Database schema updates:**

* Added `grad_year` (default: 2026) and `grad_term` (default: `MID_YEAR`) fields to the `Student` model in `prisma/schema.prisma`.
* Introduced a new `GraduationTerm` enum with values `MID_YEAR` and `END_YEAR` in `prisma/schema.prisma`.

**API changes:**

* Updated the `createStudent` function in `student_service.ts` to accept and store `grad_year` and `grad_term` from the request body.
* Added a comment in `student_service.ts` noting the need for data sanitation in the `createStudent` function.