### PR TITLE
fix: globalized submit route

### DIFF
--- a/src/api/student/student_route.ts
+++ b/src/api/student/student_route.ts
@@ -1,10 +1,14 @@
 import { Router } from "express";
 import * as studentController from "./student_controller";
+import { verifyToken } from "../auth/auth_middleware";
 
 const router = Router();
 
 //handle registration
 router.post("/submit", studentController.studentRegistration);
+
+//TODO: quick patch, fix later
+router.use(verifyToken);
 
 //fetch student profile respective to the id number
 router.get("/profile/fetch", studentController.getStudentById);

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,7 @@ const gen_limiter = rateLimit({
 
 //API ROUTES
 app.use("/api/admin", admin_limiter, verifyToken, isAdmin, adminRoutes);
-app.use("/api/student", gen_limiter, verifyToken, studentRoutes);
+app.use("/api/student", gen_limiter, studentRoutes);
 app.use("/api/auth", login_limiter, authRoutes);
 
 export default app;


### PR DESCRIPTION
This pull request updates authentication handling for student-related API routes. The main change is moving the `verifyToken` middleware from the global application level in `src/server.ts` to the individual student router in `src/api/student/student_route.ts`. This allows for more granular control over which student endpoints require authentication.

**Authentication Middleware Refactor:**

* Removed the global application of `verifyToken` middleware from all `/api/student` routes in `src/server.ts`, so authentication is no longer enforced for every student route at the app level.
* Added the `verifyToken` middleware directly to the student router in `src/api/student/student_route.ts`, after the registration endpoint, ensuring only routes after this middleware (like `/profile/fetch`) require authentication.