### PR TITLE
feat: require profile photo before booking

### DIFF
--- a/src/api/student/student_controller.ts
+++ b/src/api/student/student_controller.ts
@@ -87,6 +87,13 @@ export async function createBooking(req: StudentRequest, res: Response) {
             status: "Success"
         });
     } catch (err) {
+        if (err instanceof Error && err.message === "PROFILE_PHOTO_REQUIRED") {
+            return res.status(403).json({
+                status: "Failed",
+                message: "Please upload your profile picture before booking a pictorial schedule.",
+            });
+        }
+
         console.error(`Error: ${err}`);
         return res.status(500).json({
             status: "Failed",
@@ -127,6 +134,13 @@ export async function updateBooking(req: StudentRequest, res: Response) {
             status: "Success"
         });
     } catch (err) {
+        if (err instanceof Error && err.message === "PROFILE_PHOTO_REQUIRED") {
+            return res.status(403).json({
+                status: "Failed",
+                message: "Please upload your profile picture before changing your pictorial schedule.",
+            });
+        }
+
         console.error(`Error: ${err}`);
         return res.status(500).json({
             status: "Failed",

--- a/src/api/student/student_service.ts
+++ b/src/api/student/student_service.ts
@@ -8,6 +8,25 @@ type SolicitationPayload = {
   name: string;
 };
 
+async function assertStudentHasProfilePhoto(student_number: number) {
+  const student = await prisma.student.findUnique({
+    where: {
+      student_number,
+    },
+    select: {
+      studentDetail: {
+        select: {
+          photo_url: true,
+        },
+      },
+    },
+  });
+
+  if (!student?.studentDetail?.photo_url?.trim()) {
+    throw new Error("PROFILE_PHOTO_REQUIRED");
+  }
+}
+
 //TODO: still unsafe, need data sanitation so we pray for now :D
 export async function createStudent(body: any) {
   return await prisma.student.create({
@@ -87,6 +106,8 @@ export async function fetchBooking() {
 }
 
 export async function createBooking(student_id: number, booking_id: number, period: string) {
+  await assertStudentHasProfilePhoto(student_id);
+
   try {
     return await prisma.booking.create({
       data: {
@@ -109,6 +130,8 @@ export async function createBooking(student_id: number, booking_id: number, peri
 }
 
 export async function updateBooking(booking_id: string, booking_day_id: number, period: string, student_number: string) {
+  await assertStudentHasProfilePhoto(parseInt(student_number));
+
   try {
     return await prisma.booking.update({
       where: {


### PR DESCRIPTION
## Summary
- Blocks student booking creation when the logged-in student has no saved profile photo.
- Blocks student booking updates with the same profile-photo prerequisite.
- Returns a clear `403` response explaining that the profile picture must be uploaded before booking.

## Behavior
- Existing registration/profile access is unchanged.
- Students can still upload or update their profile photo from the dashboard.
- Booking endpoints now require `StudentDetail.photo_url` to be present before schedule registration proceeds.

## Verification
- `npm run build`
- `git diff --check`

## Frontend Pair
- Pair with auriumi/aurium-yearbook#171 for the dashboard readiness UI and disabled booking state.