### PR TITLE
rftr(server): overhaul verification proc

### DIFF
--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -363,6 +363,25 @@ export async function fetchApprovedStudents(req: Request, res: Response) {
    }
 }
 
+export async function fetchApprovedStudentsById(req: Request, res: Response) {
+  const student_id = req.params.student_id; 
+
+  if (typeof student_id !== "string" || Number.isNaN(Number(student_id))) {
+    return res.status(400).json({ reason: "Invalid student ID." });
+  }
+
+  try {
+    const result = await adminService.fv_queryStudentById(Number(student_id));
+    return res.json(result);
+
+  } catch (err) {
+    console.error("Server error: ", err);
+    return res.status(500).json({
+      status: 'Internal Server Error'
+    });
+  }
+}
+
 export async function handleFinalizeStudentUpdate(req: AdminRequest, res: Response) {
   const { studentId } = req.params;
   const { type } = req.query;

--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -348,7 +348,7 @@ export async function exportMasterlist(req: Request, res: Response) {
   }
 }
 
-export async function fetchAttendedStudents(req: Request, res: Response) {
+export async function fetchApprovedStudents(req: Request, res: Response) {
   const page = Number(req.query.page ?? 1);
   
    try {

--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -77,44 +77,6 @@ export async function getStaffDetails(req: AdminRequest, res: Response) {
   }
 } 
 
-//handle verification
-export async function handleVerify(req: AdminRequest, res: Response) {
-  try {
-    const { id } = req.params;
-    const admin_id = req.user?.admin_id;
-
-    if (!admin_id) {
-      return res.status(401).json({
-        error: "Unauthorized!"
-      });
-    } 
-
-    if (typeof id !== 'string') {
-      return res.status(400).json({
-        error: "Student ID is required!"
-      });
-    }
-
-    const result = await adminService.verifyStudent(id, admin_id);
-    
-    if (!result.success) {
-      return res.status(404).json({
-        message: result.reason
-      });
-    }
-
-    res.json({
-      status: "Success!"
-    });
-
-  } catch (err) {
-    console.error("Error: ", err);
-    res.status(500).json({
-      status: 'Internal Server Error'
-    });
-  }
-};
-
 //reject student approval
 export async function handleCancel(req: AdminRequest, res: Response) {
   try {
@@ -429,7 +391,7 @@ export async function handleFinalizeStudentStatus(req: AdminRequest, res: Respon
   }
 
   try {
-    const result = await adminService.fv_markFullyVerified(Number(id), Number(admin_id));
+    const result = await adminService.fv_markFullyVerified(Number(id), admin_id);
 
     if (!result.success) {
       return res.status(400).json({ reason: result.reason });

--- a/src/api/admin/admin_route.ts
+++ b/src/api/admin/admin_route.ts
@@ -34,6 +34,7 @@ router.post("/masterlist/reset/:id", requirePermission(Permission.STUDENT_PASSWO
 
 //final verification
 router.get("/finalize", requirePermission(Permission.FINALIZE_VIEW), adminController.fetchApprovedStudents);
+router.get("/finalize/:student_id", requirePermission(Permission.FINALIZE_VIEW), adminController.fetchApprovedStudentsById);
 router.patch("/finalize/:studentId", requirePermission(Permission.FINALIZE_UPDATE), adminController.handleFinalizeStudentUpdate);
 router.patch("/finalize", requirePermission(Permission.FINALIZE_STATUS), adminController.handleFinalizeStudentStatus);
 

--- a/src/api/admin/admin_route.ts
+++ b/src/api/admin/admin_route.ts
@@ -33,7 +33,7 @@ router.get("/masterlist", requirePermission(Permission.MASTERLIST_VIEW), adminCo
 router.post("/masterlist/reset/:id", requirePermission(Permission.STUDENT_PASSWORD_RESET), adminController.handleStudentPasswordReset);
 
 //final verification
-router.get("/finalize", requirePermission(Permission.FINALIZE_VIEW), adminController.fetchAttendedStudents);
+router.get("/finalize", requirePermission(Permission.FINALIZE_VIEW), adminController.fetchApprovedStudents);
 router.patch("/finalize/:studentId", requirePermission(Permission.FINALIZE_UPDATE), adminController.handleFinalizeStudentUpdate);
 router.patch("/finalize", requirePermission(Permission.FINALIZE_STATUS), adminController.handleFinalizeStudentStatus);
 

--- a/src/api/admin/admin_route.ts
+++ b/src/api/admin/admin_route.ts
@@ -21,9 +21,6 @@ router.get("/student", requirePermission(Permission.VERIFICATION_VIEW), adminCon
 //get unverified student by id
 router.get("/student/:id", requirePermission(Permission.VERIFICATION_VIEW), adminController.searchUnverifiedById);
 
-//verify student
-router.patch("/student/:id", requirePermission(Permission.STUDENT_VERIFY), adminController.handleVerify);
-
 //delete student record
 router.delete("/student/:id", requirePermission(Permission.STUDENT_DISCARD), adminController.handleCancel);
 

--- a/src/api/admin/admin_route.ts
+++ b/src/api/admin/admin_route.ts
@@ -25,7 +25,7 @@ router.get("/student/:id", requirePermission(Permission.VERIFICATION_VIEW), admi
 router.patch("/student/:id", requirePermission(Permission.STUDENT_VERIFY), adminController.handleVerify);
 
 //delete student record
-router.delete("/student/:id", requirePermission(Permission.STUDENT_DELETE), adminController.handleCancel);
+router.delete("/student/:id", requirePermission(Permission.STUDENT_DISCARD), adminController.handleCancel);
 
 //masterlist
 router.get("/masterlist/export", requirePermission(Permission.MASTERLIST_EXPORT), adminController.exportMasterlist);

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -984,6 +984,30 @@ export async function img_decide(image_id: number, action: string, note: string 
 }
 
 // ---------------------------------------------------------------------
+//get fv_students by id
+export async function fv_queryStudentById(id: number) {
+  const student = await prisma.student.findUnique({
+    where: {
+      student_number: id,
+      studentAuth: {
+        status: StudentStatus.REGISTERED
+      },
+    },
+    include: {
+      studentDetail: true,
+    }
+  });
+
+  if (!student) {
+    return { sucesss: false, reason: "student doesn't exist" }
+  }
+
+  if (student.studentDetail?.photo_url) {
+    student.studentDetail.photo_url = await generateReadUrl(student.studentDetail.photo_url);
+  }
+
+  return { student, total_students: 1 };
+}
 
 //get paginated registered students
 export async function fv_queryStudents(page: number) {

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -184,60 +184,6 @@ export async function resetStudentPass(id: string, email_target: string) {
   }
 }
 
-export async function verifyStudent(id: string, admin_id: string) {
-  try {
-    //student lookup
-    const student = await prisma.student.findUnique({
-      where: {
-        student_number: parseInt(id),
-      },
-      select: {
-        student_number: true,
-        school_email: true,
-        personal_email: true,
-        studentAuth: true,
-      }
-    });
-    if (!student) return { success: false, reason: "Student ID doesn't exist or already verified!" };
-
-    //generate temp pass and hash
-    const temp_pass = await generatePass();
-
-    //check if school email is null then fallback to their personal email instead
-    const email = student.school_email ? student.school_email : student.personal_email; 
-
-    //send credentials to the respective student email
-    const send_pass = await sendCreds(temp_pass.actual_pass, email);
-    if (!send_pass) return { success: false, reason: "Something went wrong when sending the password." };
-
-    //upload hashed pass to db
-    await prisma.student.update({
-      where : {
-        student_number: student.student_number
-      },
-      data: {
-        studentAuth: {
-          update: {
-            hashed_password: temp_pass.hash_pass,
-            is_verified: true,
-            status: StudentStatus.APPROVED,
-          },
-        },
-      },
-    });
-
-    //generate log if everything succeeds
-    await generateLog(parseInt(admin_id), student.student_number, AdminActions.APPROVED); 
-
-    return { success: true };
-  } catch (err: any) {
-    return { 
-      success: false, 
-      reason: "Something went wrong!"
-    };
-  }
-}
-
 export async function generateLog(admin_id: number, target_id: number, action: AdminActions) {
   return await prisma.logs.create({
     data: {
@@ -1134,36 +1080,67 @@ export async function fv_fetchAttendanceQueue() {
   return queue;
 }
 
-export async function fv_markFullyVerified(studentId: number, adminId: number) {
+export async function fv_markFullyVerified(student_id: number, admin_id: string) {
   try {
-    const auth = await prisma.studentAuth.findUnique({
-      where: { student_number: studentId },
-      select: { student_number: true },
+    const student = await prisma.student.findUnique({
+      where: { student_number: student_id },
+      select: { 
+        student_number: true,
+        school_email: true,
+        personal_email: true,
+        studentAuth: true,
+       },
     });
 
-    if (!auth) {
+    if (!student) {
       return { success: false, reason: "Student doesn't exist!" };
     }
 
     await prisma.$transaction([
       prisma.studentAuth.update({
-        where: { student_number: studentId },
+        where: { student_number: student_id },
         data: {
           status: StudentStatus.FULLY_VERIFIED,
         },
       }),
+
       prisma.logs.create({
         data: {
-          admin_id: adminId,
+          admin_id: parseInt(admin_id),
           action: AdminActions.VERIFIED,
-          target_id: studentId,
+          target_id: student_id,
         },
       }),
     ]);
 
+    //generate temp pass and hash
+    const temp_pass = await generatePass();
+
+    //check if school email is null then fallback to their personal email instead
+    const email = student.school_email ? student.school_email : student.personal_email; 
+
+    //send credentials to the respective student email
+    const send_pass = await sendCreds(temp_pass.actual_pass, email);
+    if (!send_pass) return { success: false, reason: "Something went wrong when sending the password." };
+
+    //upload hashed pass to db
+    await prisma.student.update({
+      where : {
+        student_number: student.student_number
+      },
+      data: {
+        studentAuth: {
+          update: {
+            hashed_password: temp_pass.hash_pass,
+            is_verified: true,
+          },
+        },
+      },
+    });
+
     return { success: true };
   } catch (err) {
-    console.error(`Failed to fully verify student ${studentId}:`, err);
+    console.error(`Failed to fully verify student ${student_id}:`, err);
     return {
       success: false,
       reason: "An unexpected error occurred. Please try again later.",

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -985,7 +985,7 @@ export async function img_decide(image_id: number, action: string, note: string 
 
 // ---------------------------------------------------------------------
 
-//get paginated students where status is 'ATTENDED'
+//get paginated registered students
 export async function fv_queryStudents(page: number) {
   const skip = (page - 1) * F_STUDENTS_PER_PAGE;
 
@@ -994,7 +994,7 @@ export async function fv_queryStudents(page: number) {
     take: F_STUDENTS_PER_PAGE,
     where: {
       studentAuth: {
-        status: StudentStatus.ATTENDED
+        status: StudentStatus.REGISTERED
       }
     },
     orderBy: {
@@ -1007,7 +1007,7 @@ export async function fv_queryStudents(page: number) {
 
   const total_students = await prisma.studentAuth.count({
     where: {
-      status: StudentStatus.ATTENDED
+      status: StudentStatus.REGISTERED
     }
   });
 

--- a/src/api/auth/permissions.ts
+++ b/src/api/auth/permissions.ts
@@ -8,6 +8,7 @@ export const Permission = {
     VERIFICATION_VIEW: "VERIFICATION_VIEW",
     STUDENT_VERIFY: "STUDENT_VERIFY",
     STUDENT_DELETE: "STUDENT_DELETE",
+    STUDENT_DISCARD: "STUDENT_DISCARD",
 
     // Masterlist
     MASTERLIST_VIEW: "MASTERLIST_VIEW",
@@ -45,6 +46,7 @@ export type Permission = (typeof Permission)[keyof typeof Permission];
 export const PERMISSION_MATRIX: Record<Permission, AdminRoles[]> = {
     [Permission.VERIFICATION_VIEW]: [ADMINISTRATOR, MODERATOR],
     [Permission.STUDENT_VERIFY]: [ADMINISTRATOR, MODERATOR],
+    [Permission.STUDENT_DISCARD]: [ADMINISTRATOR, MODERATOR],
     [Permission.STUDENT_DELETE]: [ADMINISTRATOR],
 
     [Permission.MASTERLIST_VIEW]: [ADMINISTRATOR, MODERATOR, MEMBER],


### PR DESCRIPTION
This pull request updates the admin "final verification" endpoints and related services to focus on students with a `REGISTERED` status instead of `ATTENDED`, and adds the ability to fetch an individual approved student by ID. The changes improve clarity in naming, align database queries with the new status, and introduce a new endpoint for fetching student details.

**API Endpoint Updates:**

* Renamed the `fetchAttendedStudents` controller and route to `fetchApprovedStudents` to better reflect that it now handles students with a `REGISTERED` status, not `ATTENDED`.
* Added a new endpoint and controller method `fetchApprovedStudentsById` to fetch a single approved (registered) student by their ID.

**Service Layer Changes:**

* Added the `fv_queryStudentById` service function to retrieve a registered student by ID, including their details and handling photo URLs.
* Updated the `fv_queryStudents` service function to query students with `REGISTERED` status instead of `ATTENDED`.