### PR TITLE
fix: harden R2 image upload handling

### DIFF
--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import * as adminService from "./admin_service";
 import * as notificationService from "./notification_service";
 import { Prisma } from "@prisma/client";
+import { isInvalidImageUploadError, isR2ConfigurationError, isYearbookImageUrlForStudent } from "../student/r2_service";
 
 interface AdminRequest extends Request {
   user?: {
@@ -555,6 +556,16 @@ export async function getImageUploadUrl(req: Request, res: Response) {
     );
     return res.json({ upload_url, photo_url });
   } catch (err) {
+    if (isInvalidImageUploadError(err)) {
+      return res.status(400).json({ reason: "Only JPG and PNG images are supported." });
+    }
+
+    if (isR2ConfigurationError(err)) {
+      return res.status(503).json({
+        reason: "Photo storage is not configured. Please check the R2 environment variables.",
+      });
+    }
+
     console.error("Image upload URL error:", err);
     return res.status(500).json({ reason: "Something went wrong generating URL" });
   }
@@ -579,7 +590,10 @@ export async function saveImageUrl(req: AdminRequest, res: Response) {
   const safeYear = parseImageYear(year);
   if (safeYear === null) return res.status(400).json({ reason: "Invalid year." });
 
-  if (typeof photo_url !== "string" || !photo_url.startsWith("https://")) {
+  if (
+    typeof photo_url !== "string" ||
+    !isYearbookImageUrlForStudent(photo_url, student_number, normalizedType as "GRADUATION" | "THEME", safeYear)
+  ) {
     return res.status(400).json({ reason: "Invalid photo URL." });
   }
 

--- a/src/api/student/r2_service.ts
+++ b/src/api/student/r2_service.ts
@@ -2,28 +2,133 @@ import { PutObjectCommand, GetObjectCommand, S3Client } from "@aws-sdk/client-s3
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import prisma from "../../config/prisma";
 
-const ACC_ID = process.env.R2_ACC_ID;
-const BUCKET = "aurium";
+const DEFAULT_BUCKET = "aurium";
+const BUCKET = (process.env.R2_BUCKET || DEFAULT_BUCKET).trim();
+const R2_CONFIG_ERROR = "R2_STORAGE_NOT_CONFIGURED";
+const INVALID_IMAGE_ERROR = "INVALID_IMAGE_UPLOAD";
 
-const s3 = new S3Client({
-    region: "auto",
-    endpoint: `https://${ACC_ID}.r2.cloudflarestorage.com`,
-    credentials: {
-        accessKeyId: process.env.R2_ACC_KEY!,
-        secretAccessKey: process.env.R2_SECRET_KEY!
-    },
-});
+const ALLOWED_IMAGE_MIME: Record<string, string[]> = {
+    "image/jpeg": ["jpg", "jpeg"],
+    "image/png": ["png"],
+};
 
-export async function generatePresignedUrl(student_number: string, ext = "jpg", mime = "image/jpeg") {
-    const key =`profile_photos/${student_number}.${ext}`;
+const PUBLIC_HOST_ENV_KEYS = [
+    "R2_PUBLIC_HOST",
+    "R2_PUBLIC_DOMAIN",
+    "R2_CDN_HOST",
+];
+
+let s3Client: S3Client | null = null;
+let s3ClientCacheKey = "";
+
+export function isR2ConfigurationError(err: unknown) {
+    return err instanceof Error && err.message === R2_CONFIG_ERROR;
+}
+
+export function isInvalidImageUploadError(err: unknown) {
+    return err instanceof Error && err.message === INVALID_IMAGE_ERROR;
+}
+
+function getR2Config() {
+    const accountId = process.env.R2_ACC_ID?.trim();
+    const accessKeyId = process.env.R2_ACC_KEY?.trim();
+    const secretAccessKey = process.env.R2_SECRET_KEY?.trim();
+
+    if (!accountId || !accessKeyId || !secretAccessKey || !BUCKET) {
+        throw new Error(R2_CONFIG_ERROR);
+    }
+
+    return {
+        accountId,
+        accessKeyId,
+        secretAccessKey,
+        bucket: BUCKET,
+    };
+}
+
+function getS3Client() {
+    const config = getR2Config();
+    const cacheKey = `${config.accountId}:${config.accessKeyId}:${config.bucket}`;
+
+    if (!s3Client || s3ClientCacheKey !== cacheKey) {
+        s3Client = new S3Client({
+            region: "auto",
+            endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
+            credentials: {
+                accessKeyId: config.accessKeyId,
+                secretAccessKey: config.secretAccessKey,
+            },
+        });
+        s3ClientCacheKey = cacheKey;
+    }
+
+    return {
+        s3: s3Client,
+        config,
+    };
+}
+
+function normalizeImageUploadInput(ext = "jpg", mime = "image/jpeg") {
+    const normalizedMime = mime.toLowerCase() === "image/jpg" ? "image/jpeg" : mime.toLowerCase();
+    const normalizedExt = ext.toLowerCase().replace(/^\./, "");
+    const allowedExtensions = ALLOWED_IMAGE_MIME[normalizedMime];
+
+    if (!allowedExtensions || !allowedExtensions.includes(normalizedExt)) {
+        throw new Error(INVALID_IMAGE_ERROR);
+    }
+
+    return {
+        ext: normalizedExt === "jpeg" ? "jpg" : normalizedExt,
+        mime: normalizedMime,
+    };
+}
+
+function buildStoredObjectUrl(key: string) {
+    const { config } = getS3Client();
+    return `https://${config.accountId}.r2.cloudflarestorage.com/${config.bucket}/${key}`;
+}
+
+function normalizeHost(host: string) {
+    try {
+        const value = host.includes("://") ? host : `https://${host}`;
+        return new URL(value).hostname.toLowerCase();
+    } catch {
+        return "";
+    }
+}
+
+function getAllowedPublicHosts(accountId: string) {
+    const hosts = new Set([`${accountId}.r2.cloudflarestorage.com`.toLowerCase()]);
+
+    for (const key of PUBLIC_HOST_ENV_KEYS) {
+        const value = process.env[key]?.trim();
+        if (!value) continue;
+
+        for (const host of value.split(",")) {
+            const normalizedHost = normalizeHost(host.trim());
+            if (normalizedHost) hosts.add(normalizedHost);
+        }
+    }
+
+    return hosts;
+}
+
+async function generateUploadUrl(key: string, mime: string) {
+    const { s3, config } = getS3Client();
     const command = new PutObjectCommand({
-        Bucket: BUCKET,
+        Bucket: config.bucket,
         Key: key,
         ContentType: mime,
     });
 
-    const upload_url = await getSignedUrl(s3, command, { expiresIn: 120 });
-    const photo_url = `https://${ACC_ID}.r2.cloudflarestorage.com/${BUCKET}/${key}`;
+    return getSignedUrl(s3, command, { expiresIn: 120 });
+}
+
+export async function generatePresignedUrl(student_number: string, ext = "jpg", mime = "image/jpeg") {
+    const upload = normalizeImageUploadInput(ext, mime);
+    const key = `profile_photos/${student_number}.${upload.ext}`;
+    const upload_url = await generateUploadUrl(key, upload.mime);
+    const photo_url = buildStoredObjectUrl(key);
 
     return { upload_url, photo_url };
 }
@@ -35,47 +140,91 @@ export async function generateImageUploadUrl(
     ext = "jpg",
     mime = "image/jpeg"
 ) {
+    const upload = normalizeImageUploadInput(ext, mime);
     const folder = type === "GRADUATION" ? "graduation_photos" : "theme_photos";
-    const key = `${folder}/${year}/${student_number}.${ext}`;
-    const command = new PutObjectCommand({
-        Bucket: BUCKET,
-        Key: key,
-        ContentType: mime,
-    });
-
-    const upload_url = await getSignedUrl(s3, command, { expiresIn: 120 });
-    const photo_url = `https://${ACC_ID}.r2.cloudflarestorage.com/${BUCKET}/${key}`;
+    const key = `${folder}/${year}/${student_number}.${upload.ext}`;
+    const upload_url = await generateUploadUrl(key, upload.mime);
+    const photo_url = buildStoredObjectUrl(key);
 
     return { upload_url, photo_url };
 }
 
 function extractKey(photo_url: string): string | null {
     try {
+        const config = getR2Config();
         const { hostname, pathname } = new URL(photo_url);
-        if (hostname.includes('r2.cloudflarestorage.com')) {
-            // Path: /<bucket>/<key> — strip the bucket prefix
-            return pathname.replace(`/${BUCKET}/`, '/').slice(1);
+        const normalizedHost = hostname.toLowerCase();
+        const r2Host = `${config.accountId}.r2.cloudflarestorage.com`.toLowerCase();
+
+        if (!getAllowedPublicHosts(config.accountId).has(normalizedHost)) {
+            return null;
         }
-        // Custom domain (e.g. static.auriumi.cloud): path is already /<key>
+
+        if (normalizedHost === r2Host) {
+            const bucketPrefix = `/${config.bucket}/`;
+            return pathname.startsWith(bucketPrefix)
+                ? pathname.slice(bucketPrefix.length)
+                : null;
+        }
+
+        // Configured custom domain paths are expected to be stored as /<key>.
         return pathname.slice(1) || null;
     } catch {
         return null;
     }
 }
 
+function isAllowedImageKey(key: string) {
+    return /\.(jpe?g|png)$/i.test(key);
+}
+
+export function isProfilePhotoUrlForStudent(photo_url: string, student_number: string | number) {
+    const key = extractKey(photo_url);
+    if (!key || !isAllowedImageKey(key)) return false;
+
+    return new RegExp(`^profile_photos/${student_number}\\.(jpe?g|png)$`, "i").test(key);
+}
+
+export function isYearbookImageUrlForStudent(
+    photo_url: string,
+    student_number: string | number,
+    type: "GRADUATION" | "THEME",
+    year: number,
+) {
+    const key = extractKey(photo_url);
+    if (!key || !isAllowedImageKey(key)) return false;
+
+    const folder = type === "GRADUATION" ? "graduation_photos" : "theme_photos";
+    return new RegExp(`^${folder}/${year}/${student_number}\\.(jpe?g|png)$`, "i").test(key);
+}
+
 export async function generateReadUrl(photo_url: string | null): Promise<string | null> {
     if (!photo_url) return null;
     const key = extractKey(photo_url);
     if (!key) return null;
-    const command = new GetObjectCommand({ Bucket: BUCKET, Key: key });
-    return getSignedUrl(s3, command, { expiresIn: 3600 });
+
+    try {
+        const { s3, config } = getS3Client();
+        const command = new GetObjectCommand({ Bucket: config.bucket, Key: key });
+        return await getSignedUrl(s3, command, { expiresIn: 3600 });
+    } catch (err) {
+        console.error("R2 read URL error:", err instanceof Error ? err.message : err);
+        return null;
+    }
 }
 
 export async function uploadPhotoUrl(student_number: string, photo_url: string) {
+    if (!isProfilePhotoUrlForStudent(photo_url, student_number)) {
+        return {
+            success: false,
+            reason: "Invalid profile photo URL"
+        };
+    }
+
     const student = await prisma.student.findUnique({
         where: {
-            student_number: parseInt(student_number) 
-        } 
+            student_number: parseInt(student_number)
+        }
     });
 
     if (!student) {
@@ -94,5 +243,5 @@ export async function uploadPhotoUrl(student_number: string, photo_url: string) 
         }
     });
 
-    return { success: true }
+    return { success: true };
 }

--- a/src/api/student/student_controller.ts
+++ b/src/api/student/student_controller.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { generatePresignedUrl } from "./r2_service";
 import * as studentService from "./student_service";
 import * as r2Service from "./r2_service";
 
@@ -156,14 +155,27 @@ export async function getPhotoUploadUrl(req: StudentRequest, res: Response) {
         return res.status(401).json({ error: "Unauthorized" });
     }
 
-    const ext = req.query.ext as string || "jpg";
-    const mime = req.query.mime as string || "image/jpg";
+    const ext = typeof req.query.ext === "string" ? req.query.ext : "jpg";
+    const mime = typeof req.query.mime === "string" ? req.query.mime : "image/jpeg";
 
     try {
-        const { upload_url, photo_url } = await generatePresignedUrl(student_number, ext, mime);
+        const { upload_url, photo_url } = await r2Service.generatePresignedUrl(student_number, ext, mime);
         res.json({ upload_url, photo_url });
     } catch (err) {
-        res.status(500).json({ error: "Something went wrong generating URL" })
+        if (r2Service.isInvalidImageUploadError(err)) {
+            return res.status(400).json({
+                error: "Only JPG and PNG images are supported.",
+            });
+        }
+
+        if (r2Service.isR2ConfigurationError(err)) {
+            return res.status(503).json({
+                error: "Photo storage is not configured. Please check the R2 environment variables.",
+            });
+        }
+
+        console.error("Profile upload URL error:", err);
+        res.status(500).json({ error: "Something went wrong generating URL" });
     }
 }
 
@@ -174,8 +186,8 @@ export async function savePhotoUrl(req: StudentRequest, res: Response) {
     }
 
     const { photo_url } = req.body;
-    if (!photo_url || !photo_url.startsWith("https://")) {
-        return res.status(400).json({ error: "Invalid URL" });
+    if (typeof photo_url !== "string" || !r2Service.isProfilePhotoUrlForStudent(photo_url, student_number)) {
+        return res.status(400).json({ error: "Invalid profile photo URL" });
     }
 
     try {
@@ -187,9 +199,10 @@ export async function savePhotoUrl(req: StudentRequest, res: Response) {
                 reason: result.reason 
             });
         }
-        return res.json({ sucess: true });
+        return res.json({ success: true });
 
-    } catch {
+    } catch (err) {
+        console.error("Save profile photo error:", err);
         res.status(500).json({ error: "Something went wrong saving photo URL" });
     }
 }


### PR DESCRIPTION
## Summary
- Validates Cloudflare R2 configuration before generating upload/read signed URLs.
- Returns clear `400` responses for unsupported image types and `503` responses when R2 storage is not configured.
- Restricts saved profile/yearbook image URLs to the configured R2 account or explicit public/CDN hosts.
- Prevents profile/dashboard read flows from crashing when read URL signing fails; existing stored URLs are used as fallback.

## Root Cause
- The local upload failure was coming from R2 presigning: invalid or missing R2 credentials can trigger the AWS SDK error `Resolved credential object is not valid`.
- Without this patch, production would also fail during upload if `R2_ACC_ID`, `R2_ACC_KEY`, or `R2_SECRET_KEY` are missing/invalid.

## Production Notes
- Required env vars: `R2_ACC_ID`, `R2_ACC_KEY`, `R2_SECRET_KEY`.
- Optional env vars: `R2_BUCKET`, `R2_PUBLIC_HOST`, `R2_PUBLIC_DOMAIN`, or `R2_CDN_HOST` if saved image URLs use a custom public domain.
- Bucket CORS still needs to allow `PUT` from the deployed frontend domain.

## Verification
- `npm run build`
- `git diff --check origin/main..HEAD`

## Frontend Pair
- Requires auriumi/aurium-yearbook#173 for the student-facing upload failure handling.