### PR TITLE
fix: handle student dashboard API failures

### DIFF
--- a/src/api/student/student_controller.ts
+++ b/src/api/student/student_controller.ts
@@ -66,14 +66,16 @@ export async function getStudentById(req: StudentRequest, res: Response) {
         //get id from jwt paylaod
         const student_number = req.user?.student_number;
         if (!student_number) {
-            res.status(404).json({ error: "Invalid request!"});
+            return res.status(401).json({ error: "Invalid request!"});
         }
 
         const result = await studentService.getStudentProfile(parseInt(student_number!));
         if (!result.success) {
-            res.status(404).json({ error: result.reason });
+            const status = result.reason === "Student doesn't exist!" ? 404 : 500;
+            return res.status(status).json({ error: result.reason });
         }
-        res.json(result.student);
+
+        return res.json(result.student);
 
     } catch (err) {
         console.error("Error: ", err);
@@ -85,8 +87,16 @@ export async function getStudentById(req: StudentRequest, res: Response) {
 };
 
 export async function fetchBooking(req: Request, res: Response) {
-    const list_booking = await studentService.fetchBooking();
-    return res.json(list_booking);
+    try {
+        const list_booking = await studentService.fetchBooking();
+        return res.json(list_booking);
+    } catch (err) {
+        console.error("Fetch booking schedules error:", err);
+        return res.status(500).json({
+            status: "Failed",
+            message: "Unable to load booking schedules.",
+        });
+    }
 };
 
 export async function createBooking(req: StudentRequest, res: Response) {


### PR DESCRIPTION
## Summary
- Returns immediately when student profile auth/lookup fails, avoiding response fall-through.
- Uses `500` for profile load failures caused by backend/database errors instead of masking them as `404`.
- Wraps student schedule fetch in a controller-level error response with logging.

## Why
- After the hourly schedule deployment, `/api/student/profile/fetch` can fail if the production DB schema has not been pushed for `BookingSlot`/`booking_slot_id`.
- The controller previously mapped all profile service failures to `404` and continued execution, which made production debugging confusing.

## Production Note
- This does not replace the required database schema sync. The VPS DB still needs the new `BookingSlot` table and `Booking.booking_slot_id` column before the hourly schedule feature can work.

## Verification
- `npm run build`
- `git diff --check origin/main..HEAD`

## Frontend Pair
- Pair with auriumi/aurium-yearbook#174 for dashboard-side graceful failure handling.