### PR TITLE
fix: return duplicate registration warning

### DIFF
--- a/src/api/student/student_controller.ts
+++ b/src/api/student/student_controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { Prisma } from "@prisma/client";
 import { generatePresignedUrl } from "./r2_service";
 import * as studentService from "./student_service";
 import * as r2Service from "./r2_service";
@@ -35,6 +36,10 @@ function bookingErrorStatus(code: studentService.BookingRequestError["code"]) {
     }
 }
 
+function isDuplicateRegistrationError(err: unknown) {
+    return err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002";
+}
+
 //create student upon registration
 export async function studentRegistration(req: Request, res: Response) {
     try {
@@ -52,6 +57,14 @@ export async function studentRegistration(req: Request, res: Response) {
             status: "Success",
         });
     } catch (err) {
+        if (isDuplicateRegistrationError(err)) {
+            return res.status(409).json({
+                status: "Failed",
+                code: "DUPLICATE_REGISTRATION",
+                message: "Duplicate submission detected. A pre-registration entry already exists for this Student ID Number.",
+            });
+        }
+
         console.error(`Error: ${err}`);
         return res.status(500).json({
             status: "Failed",

--- a/src/api/student/student_controller.ts
+++ b/src/api/student/student_controller.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { Prisma } from "@prisma/client";
 import { generatePresignedUrl } from "./r2_service";
 import * as studentService from "./student_service";
 import * as r2Service from "./r2_service";
@@ -36,10 +35,6 @@ function bookingErrorStatus(code: studentService.BookingRequestError["code"]) {
     }
 }
 
-function isDuplicateRegistrationError(err: unknown) {
-    return err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002";
-}
-
 //create student upon registration
 export async function studentRegistration(req: Request, res: Response) {
     try {
@@ -57,11 +52,11 @@ export async function studentRegistration(req: Request, res: Response) {
             status: "Success",
         });
     } catch (err) {
-        if (isDuplicateRegistrationError(err)) {
+        if (studentService.isDuplicateRegistrationError(err)) {
             return res.status(409).json({
                 status: "Failed",
                 code: "DUPLICATE_REGISTRATION",
-                message: "Duplicate submission detected. A pre-registration entry already exists for this Student ID Number.",
+                message: "This ID number has already been registered. Please contact us if this is incorrect.",
             });
         }
 

--- a/src/api/student/student_service.ts
+++ b/src/api/student/student_service.ts
@@ -25,6 +25,10 @@ export class BookingRequestError extends Error {
   }
 }
 
+export function isDuplicateRegistrationError(err: unknown) {
+  return err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002";
+}
+
 type SolicitationPayload = {
   type: SolicitationType;
   title: string;


### PR DESCRIPTION
## Summary
- Converts duplicate pre-registration inserts into a clear `409 Conflict` response.
- Adds a stable `DUPLICATE_REGISTRATION` response code for duplicate student-number submissions.
- Keeps unexpected registration failures as server errors.

## Behavior
- If a student submits the same Student ID Number again, the API returns:
  - `status: Failed`
  - `code: DUPLICATE_REGISTRATION`
  - a student-friendly duplicate-submission message

## Verification
- `npm run build`
- `git diff --check`

## Frontend Pair
- Requires auriumi/aurium-yearbook#175 to display the warning in the pre-registration wizard.