### PR TITLE
Add moderator booking override endpoint

### DIFF
--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -255,6 +255,33 @@ export async function handleUpdateScheduleCapacity(req: AdminRequest, res: Respo
   }
 }
 
+export async function handleOverrideStudentBooking(req: AdminRequest, res: Response) {
+  const { studentNumber } = req.params;
+  const bookingSlotId = Number(req.body?.booking_slot_id);
+
+  if (!studentNumber || Number.isNaN(Number(studentNumber))) {
+    return res.status(400).json({ reason: "Invalid student ID." });
+  }
+
+  if (!Number.isInteger(bookingSlotId) || bookingSlotId <= 0) {
+    return res.status(400).json({ reason: "Please select a valid booking slot." });
+  }
+
+  try {
+    const result = await adminService.overrideStudentBooking(Number(studentNumber), bookingSlotId);
+    if (!result.success) {
+      return res.status(400).json({ reason: result.reason });
+    }
+
+    return res.json({ success: true });
+  } catch (err) {
+    console.error("Server error: ", err);
+    return res.status(500).json({
+      status: "Internal Server Error"
+    });
+  }
+}
+
 //fetch students based on filter type
 export async function fetchMasterlist(req: Request, res: Response) {
   const id = req.query.id;

--- a/src/api/admin/admin_route.ts
+++ b/src/api/admin/admin_route.ts
@@ -46,6 +46,7 @@ router.post("/book/add", requirePermission(Permission.BOOKING_CREATE), adminCont
 router.get("/book/fetch", requirePermission(Permission.BOOKING_VIEW), adminController.fetchSchedule);
 router.patch("/book/toggle", requirePermission(Permission.BOOKING_TOGGLE), adminController.handleToggleScheduleState);
 router.patch("/book/update", requirePermission(Permission.BOOKING_UPDATE), adminController.handleUpdateScheduleCapacity);
+router.patch("/book/override/:studentNumber", requirePermission(Permission.BOOKING_OVERRIDE), adminController.handleOverrideStudentBooking);
 
 // staff role management (Administrator only)
 router.get("/staff/list", requirePermission(Permission.STAFF_VIEW), adminController.fetchStaffList);

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -595,20 +595,17 @@ export async function overrideStudentBooking(studentNumber: number, bookingSlotI
         },
       });
 
-      if (!student?.studentAuth) {
+      if (!student) {
         return {
           success: false,
           reason: "Student doesn't exist."
         };
       }
 
-      if (
-        student.studentAuth.status === StudentStatus.ATTENDED ||
-        student.studentAuth.status === StudentStatus.FULLY_VERIFIED
-      ) {
+      if (student.studentAuth?.status !== StudentStatus.BOOKED) {
         return {
           success: false,
-          reason: "This student has already attended and cannot be rescheduled."
+          reason: "Only booked students can be rescheduled."
         };
       }
 
@@ -619,9 +616,6 @@ export async function overrideStudentBooking(studentNumber: number, bookingSlotI
           reason: "No confirmed booking found for this student."
         };
       }
-
-      await tx.$queryRaw`SELECT "id" FROM "Booking" WHERE "id" = ${currentBooking.id} FOR UPDATE`;
-      await tx.$queryRaw`SELECT "id" FROM "BookingSlot" WHERE "id" = ${bookingSlotId} FOR UPDATE`;
 
       const slot = await tx.bookingSlot.findUnique({
         where: {

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -561,6 +561,160 @@ export async function updateScheduleCapacity(id: number, session: string, new_ca
   }
 }
 
+export async function overrideStudentBooking(studentNumber: number, bookingSlotId: number) {
+  if (!Number.isInteger(studentNumber) || studentNumber <= 0 || !Number.isInteger(bookingSlotId) || bookingSlotId <= 0) {
+    return {
+      success: false,
+      reason: "Invalid booking override request."
+    };
+  }
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const student = await tx.student.findUnique({
+        where: {
+          student_number: studentNumber,
+        },
+        select: {
+          student_number: true,
+          studentAuth: {
+            select: {
+              status: true,
+            },
+          },
+          booking: {
+            orderBy: {
+              created_at: "desc",
+            },
+            take: 1,
+            select: {
+              id: true,
+              booking_slot_id: true,
+            },
+          },
+        },
+      });
+
+      if (!student?.studentAuth) {
+        return {
+          success: false,
+          reason: "Student doesn't exist."
+        };
+      }
+
+      if (
+        student.studentAuth.status === StudentStatus.ATTENDED ||
+        student.studentAuth.status === StudentStatus.FULLY_VERIFIED
+      ) {
+        return {
+          success: false,
+          reason: "This student has already attended and cannot be rescheduled."
+        };
+      }
+
+      const currentBooking = student.booking[0];
+      if (!currentBooking) {
+        return {
+          success: false,
+          reason: "No confirmed booking found for this student."
+        };
+      }
+
+      await tx.$queryRaw`SELECT "id" FROM "Booking" WHERE "id" = ${currentBooking.id} FOR UPDATE`;
+      await tx.$queryRaw`SELECT "id" FROM "BookingSlot" WHERE "id" = ${bookingSlotId} FOR UPDATE`;
+
+      const slot = await tx.bookingSlot.findUnique({
+        where: {
+          id: bookingSlotId,
+        },
+        include: {
+          booking_day: true,
+        },
+      });
+
+      if (!slot) {
+        return {
+          success: false,
+          reason: "The selected booking slot does not exist."
+        };
+      }
+
+      if (!slot.is_open || !slot.booking_day.is_open) {
+        return {
+          success: false,
+          reason: "The selected schedule is closed."
+        };
+      }
+
+      if (isPastUtcDate(slot.booking_day.date)) {
+        return {
+          success: false,
+          reason: "The selected schedule date has already passed."
+        };
+      }
+
+      if (slot.capacity <= 0) {
+        return {
+          success: false,
+          reason: "The selected booking slot is not available."
+        };
+      }
+
+      if (currentBooking.booking_slot_id === slot.id) {
+        return {
+          success: true,
+        };
+      }
+
+      const bookedCount = await tx.booking.count({
+        where: {
+          booking_slot_id: slot.id,
+          NOT: {
+            id: currentBooking.id,
+          },
+        },
+      });
+
+      if (bookedCount >= slot.capacity) {
+        return {
+          success: false,
+          reason: "The selected booking slot is already full."
+        };
+      }
+
+      await tx.booking.update({
+        where: {
+          id: currentBooking.id,
+        },
+        data: {
+          booking_day_id: slot.booking_day_id,
+          booking_slot_id: slot.id,
+          period: slot.period,
+        },
+      });
+
+      await tx.studentAuth.update({
+        where: {
+          student_number: studentNumber,
+        },
+        data: {
+          status: StudentStatus.BOOKED,
+        },
+      });
+
+      return {
+        success: true,
+      };
+    });
+  } catch (err) {
+    console.error("Booking override error:", err);
+    return {
+      success: false,
+      reason: "Something went wrong while updating the booking."
+    };
+  }
+}
+
 export async function m_queryByFilter(page: number, dept: string, course: string, major: string, status: string) {
   const safe_page = page > 0 ? page : 1;
   const skip = (safe_page - 1) * M_STUDENTS_PER_PAGE;

--- a/src/api/auth/permissions.ts
+++ b/src/api/auth/permissions.ts
@@ -29,6 +29,7 @@ export const Permission = {
     BOOKING_CREATE: "BOOKING_CREATE",
     BOOKING_TOGGLE: "BOOKING_TOGGLE",
     BOOKING_UPDATE: "BOOKING_UPDATE",
+    BOOKING_OVERRIDE: "BOOKING_OVERRIDE",
 
     // Staff management
     STAFF_VIEW: "STAFF_VIEW",
@@ -64,6 +65,7 @@ export const PERMISSION_MATRIX: Record<Permission, AdminRoles[]> = {
     [Permission.BOOKING_CREATE]: [ADMINISTRATOR],
     [Permission.BOOKING_TOGGLE]: [ADMINISTRATOR],
     [Permission.BOOKING_UPDATE]: [ADMINISTRATOR],
+    [Permission.BOOKING_OVERRIDE]: [ADMINISTRATOR, MODERATOR],
 
     [Permission.STAFF_VIEW]: [ADMINISTRATOR],
     [Permission.STAFF_MANAGE_ROLE]: [ADMINISTRATOR],


### PR DESCRIPTION
## Summary
- Adds a dedicated booking override permission for administrators and moderators.
- Adds `PATCH /api/admin/book/override/:studentNumber` to move an existing booking to a new valid slot without creating duplicate bookings.
- Keeps override validation strict: target slot must be open, future-dated, available, and not full; attended or fully verified students cannot be rescheduled.

## Why
Student schedule changes should go through committee approval after student-side booking changes are locked.

## UI Pairing
- Pairs with auriumi/aurium-yearbook#184 for the moderator/admin override UI.

## Testing
- `npm run build`