### PR TITLE
Clarify year-end verification status flow

### DIFF
--- a/src/api/admin/admin_controller.ts
+++ b/src/api/admin/admin_controller.ts
@@ -398,7 +398,7 @@ export async function handleFinalizeStudentStatus(req: AdminRequest, res: Respon
   }
 
   try {
-    const result = await adminService.fv_markFullyVerified(Number(id), admin_id);
+    const result = await adminService.fv_markVerified(Number(id), admin_id);
 
     if (!result.success) {
       return res.status(400).json({ reason: result.reason });

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -1229,7 +1229,7 @@ export async function fv_markVerified(student_id: number, admin_id: string) {
       prisma.studentAuth.update({
         where: { student_number: student_id },
         data: {
-          status: StudentStatus.APPROVED,
+          status: StudentStatus.FULLY_VERIFIED,
         },
       }),
 

--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -1209,7 +1209,7 @@ export async function fv_fetchAttendanceQueue() {
   return queue;
 }
 
-export async function fv_markFullyVerified(student_id: number, admin_id: string) {
+export async function fv_markVerified(student_id: number, admin_id: string) {
   try {
     const student = await prisma.student.findUnique({
       where: { student_number: student_id },
@@ -1229,7 +1229,7 @@ export async function fv_markFullyVerified(student_id: number, admin_id: string)
       prisma.studentAuth.update({
         where: { student_number: student_id },
         data: {
-          status: StudentStatus.FULLY_VERIFIED,
+          status: StudentStatus.APPROVED,
         },
       }),
 
@@ -1269,7 +1269,7 @@ export async function fv_markFullyVerified(student_id: number, admin_id: string)
 
     return { success: true };
   } catch (err) {
-    console.error(`Failed to fully verify student ${student_id}:`, err);
+    console.error(`Failed to verify student ${student_id}:`, err);
     return {
       success: false,
       reason: "An unexpected error occurred. Please try again later.",


### PR DESCRIPTION
## Summary
- Keeps the year-end moderator verification flow compatible with old records by continuing to store `StudentStatus.FULLY_VERIFIED`.
- Leaves `APPROVED` unused/deprecated for this flow.
- Clarifies the service helper name/error wording around the moderator verification step.

## Flow Note
For year-end students, `FULLY_VERIFIED` remains the verification/access step so existing records and new records stay consistent. Booking and attendance continue to happen after that.

## Testing
- `npm run build`