### PR TITLE
Fix scanner attendance roster photo URLs

### DIFF
--- a/src/api/admin/admin_service.ts
+++ b/src/api/admin/admin_service.ts
@@ -266,6 +266,39 @@ export async function addSchedule(date: string, am_cap: number, pm_cap: number) 
   });
 }
 
+type BookingWithStudentPhoto = {
+  student?: {
+    studentDetail?: {
+      photo_url: string | null;
+    } | null;
+    photo_url?: string | null;
+  } | null;
+};
+
+async function attachReadableStudentPhoto(
+  booking: BookingWithStudentPhoto,
+  photoCache: Map<string, Promise<string>>
+) {
+  const rawPhotoUrl = booking.student?.studentDetail?.photo_url;
+
+  if (!booking.student) return;
+
+  if (!rawPhotoUrl) {
+    booking.student.photo_url = null;
+    return;
+  }
+
+  let readablePhotoUrl = photoCache.get(rawPhotoUrl);
+  if (!readablePhotoUrl) {
+    readablePhotoUrl = generateReadUrl(rawPhotoUrl).then((url) => url ?? rawPhotoUrl);
+    photoCache.set(rawPhotoUrl, readablePhotoUrl);
+  }
+
+  const signedPhotoUrl = await readablePhotoUrl;
+  booking.student.studentDetail = { photo_url: signedPhotoUrl };
+  booking.student.photo_url = signedPhotoUrl;
+}
+
 //fetch schedule per day
 //TODO: paginate query or cache :P
 export async function fetchSchedule() {
@@ -283,6 +316,11 @@ export async function fetchSchedule() {
                   first_name: true,
                   last_name: true,
                   student_number: true,
+                  studentDetail: {
+                    select: {
+                      photo_url: true,
+                    },
+                  },
                   studentAuth: {
                     select: {
                       status: true
@@ -302,6 +340,11 @@ export async function fetchSchedule() {
               first_name: true,
               last_name: true,
               student_number: true,
+              studentDetail: {
+                select: {
+                  photo_url: true,
+                },
+              },
               studentAuth: {
                 select: {
                   status: true
@@ -313,6 +356,16 @@ export async function fetchSchedule() {
       },
     },
   });
+
+  const photoCache = new Map<string, Promise<string>>();
+  await Promise.all(
+    bookingDays.flatMap((day) => [
+      ...day.slots.flatMap((slot) =>
+        slot.bookings.map((booking) => attachReadableStudentPhoto(booking, photoCache))
+      ),
+      ...day.bookings.map((booking) => attachReadableStudentPhoto(booking, photoCache)),
+    ])
+  );
 
   return bookingDays.map((day) => ({
     ...day,


### PR DESCRIPTION
## Summary
- Includes each booked student's reference profile photo in the admin schedule response used by the attendance scanner.
- Converts stored R2 photo URLs into readable signed URLs before returning `/api/admin/book/fetch`.
- Caches repeated photo signing work within the request so duplicate booking references do not generate duplicate signed-url calls.

## Why
The scanner roster is built from schedule bookings. That response previously returned student names and attendance status, but not `studentDetail.photo_url`, so the scanner UI had no real photo URL to render.

## Implementation Notes
- Adds `studentDetail.photo_url` to both slot-level and day-level booking student selects.
- Adds a small helper to attach a browser-readable `student.photo_url` while preserving the nested `studentDetail.photo_url` shape for frontend compatibility.
- Does not touch authentication, login, or captcha behavior.

## Testing
- `npm run build`

## Companion PR
- Frontend: https://github.com/auriumi/aurium-yearbook/pull/186

## Review Notes
- Signed photo URLs expire after the existing R2 read URL expiry window, so long-open scanner sessions may need schedule refresh to renew image URLs.