### PR TITLE
fix: proper client ip resolution for rate limit

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import adminRoutes from "./api/admin/admin_route";
 import authRoutes from "./api/auth/auth_route";
 
 const app = express();
+app.set("trust proxy", 1);
 
 const corsConfig = {
   origin: process.env.NODE_ENV == "production"

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,14 +28,14 @@ app.use(express.json());
 app.use(cookieParser());
 
 const login_limiter = rateLimit({
-  windowMs: 3 * 60 * 1000, //5 mins (3mins ug)
+  windowMs: 5 * 60 * 1000, //5 mins
   limit: 10,
   message: "Too many login attempts, please try again later",
   legacyHeaders: false
 });
 
 const admin_limiter = rateLimit({
-  windowMs: 1 * 60 * 1000, //3 mins (1mins ug)
+  windowMs: 3 * 60 * 1000, //3 mins
   limit: 100,
   message: "Too many request, please try again later :P",
   legacyHeaders: false


### PR DESCRIPTION
Server configuration:

[`src/server.ts`](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R16): Added `app.set("trust proxy", 1);` to ensure Express correctly identifies the client IP address and protocol when behind a reverse proxy (such as when deployed on Heroku or similar platforms).